### PR TITLE
Phase 1: dependency cleanup (guava/POI bumps, remove stray Boot 1.3.5 BOM import)

### DIFF
--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -44,13 +44,6 @@
     <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.5.RELEASE</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.nmdp.validation</groupId>
         <artifactId>ld-validation</artifactId>
         <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
   	<dependency>
   		<groupId>com.google.guava</groupId>
   		<artifactId>guava</artifactId>
-  		<version>31.1-jre</version>
+  		<version>33.7.1-jre</version>
   	</dependency>
   	<!-- API, java.xml.bind module -->
 	<dependency>
@@ -90,12 +90,12 @@
   	<dependency>
   		<groupId>org.apache.poi</groupId>
   		<artifactId>poi-ooxml</artifactId>
-  		<version>5.2.2</version>
+  		<version>5.5.1</version>
   	</dependency>
   	<dependency>
   		<groupId>org.apache.poi</groupId>
   		<artifactId>poi</artifactId>
-  		<version>5.2.2</version>
+  		<version>5.5.1</version>
   	</dependency>
       <dependency>
         <groupId>org.dishevelled</groupId>


### PR DESCRIPTION
First phase of a broader cleanup/modernization pass (tracked in a private Notion doc). Low-risk changes only:

- Bump `guava` 31.1-jre → 33.7.1-jre
- Bump `poi`/`poi-ooxml` 5.2.2 → 5.5.1
- Remove a stray `spring-boot-starter-parent:1.3.5.RELEASE` (2016) BOM import in `ld-service/pom.xml` that was layered alongside the root parent's `spring-boot-starter-parent:2.7.1`. It looked like dead leftover config and could silently downgrade managed dependency versions for anything covered by that old BOM. `ld-service` already gets managed versions via the `ld-multimodule` → `spring-boot-starter-parent:2.7.1` parent chain, so this import wasn't needed.

**Verification:** `mvn clean package` and `mvn test` both pass locally under JDK 17 (matching CircleCI's `cimg/openjdk:17.0`), full reactor build green.

Later phases (not in this PR): swapping dead/alpha dependency coordinates, a Spring Boot 3 + springdoc-openapi migration, performance baselining, and a documentation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)