### PR TITLE
Phase 2: drop hardcoded alpha/redundant dependency coordinates in ld-service

### DIFF
--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -78,13 +78,11 @@
       <dependency>
           <groupId>javax.validation</groupId>
           <artifactId>validation-api</artifactId>
-          <version>2.0.1.Final</version>
           <scope>provided</scope>
-      </dependency>   
+      </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.0-alpha16</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -97,7 +95,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.3.0-alpha16</version>
         </dependency>
   </dependencies>
 


### PR DESCRIPTION
Second phase of the cleanup/modernization pass (Phase 1: #2).

- `logback-classic`/`logback-core` were pinned to `1.3.0-alpha16` — an **alpha** build. Dropped the hardcoded versions so they resolve from the Spring Boot 2.7.1 BOM instead → stable `1.2.11`.
- `javax.validation:validation-api` was pinned to `2.0.1.Final`, duplicating exactly what the Boot 2.7.1 BOM already manages. Dropped the redundant version so it's BOM-managed consistently.

**Deliberately not changed:** `mysql:mysql-connector-java`. Spring Boot 2.7.x's BOM still manages the old `mysql:mysql-connector-java` coordinates — the `com.mysql:mysql-connector-j` rename only becomes the BOM-managed default starting with Spring Boot 3.1. Swapping it now would mean hand-pinning a version outside the BOM for no real benefit; deferring it to the Phase 3 Spring Boot 3 migration where it fits naturally.

**Verification:**
- `mvn dependency:tree` confirms `logback-classic`/`logback-core` now resolve to `1.2.11`, and `validation-api` still resolves to `2.0.1.Final` (same value, no longer hardcoded)
- `mvn clean test` passes on JDK 17 (matching CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)