### PR TITLE
Vulnerability pass: pin logback to 1.2.13 in ld-service (closes CVE-2023-6378)

### DIFF
--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -80,9 +80,15 @@
           <artifactId>validation-api</artifactId>
           <scope>provided</scope>
       </dependency>
+        <!-- Version pinned above the Boot 2.7.1 BOM's managed 1.2.11: closes CVE-2023-6378
+             (GHSA-vmq6-5m68-f53m), fixed at 1.2.13, the last release ever made on the 1.2.x
+             line. Later logback CVEs (2024-2026) are only fixed on the 1.3.x/1.5.x lines,
+             which require slf4j-api 2.x, so those are deferred to the Spring Boot 3
+             migration (Phase 3) rather than risking a slf4j 1.x/2.x mismatch under Boot 2.7.1. -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>1.2.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -95,6 +101,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+            <version>1.2.13</version>
         </dependency>
   </dependencies>
 


### PR DESCRIPTION
Result of a vulnerability audit pass (separate from the phased modernization plan).

Boot 2.7.1's BOM manages logback at `1.2.11`, which is vulnerable to **CVE-2023-6378** (GHSA-vmq6-5m68-f53m, high severity, logback receiver-component deserialization DoS) — fixed at `1.2.13`, the last release ever made on the 1.2.x line (Nov 2023). Not actually exploitable in this app today (no `logback.xml`, no receiver component configured anywhere), but fixing it removes the exposure regardless.

**Note on Dependabot:** it marked this alert "fixed" after the Phase 1/2 PRs merged, but that's inaccurate — Dependabot doesn't reliably resolve Maven versions inherited through parent-BOM chains, and `1.2.11` (confirmed via `mvn dependency:tree`) is still within the vulnerable range (`< 1.2.13`). I verified against the raw GHSA version ranges directly rather than trusting the alert's status label.

**Deferred to Phase 3 (Boot 3 migration):** 5 other open logback CVEs (2 medium, 3 low) are only patched on the 1.3.x/1.5.x lines, which require `slf4j-api 2.x`. Boot 2.7.1 manages `slf4j-api 1.7.36`, and logback 1.3.x uses an incompatible SLF4J provider-discovery mechanism — forcing that jump now risks breaking `ld-service`'s logging bootstrap at startup, with zero test coverage to catch it. Boot 3's BOM manages slf4j 2.x + a current logback together as an already-tested combination, so that's the safer place for the rest of this cleanup.

**Also checked and already clear:** `guava` (33.7.1-jre, Phase 1), `poi`/`poi-ooxml` (5.5.1, Phase 1), `gson` (2.8.9, fixed in repo history) — all past their respective CVE-patched versions already.

**Verification:** `mvn dependency:tree` confirms `ld-service` resolves logback to `1.2.13`; `mvn clean test` passes on JDK 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)