### PR TITLE
Phase 3b: replace springfox-swagger2 with springdoc-openapi-ui (fixes ld-service startup crash)

### DIFF
--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -60,10 +60,22 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-web</artifactId>
       </dependency>
-      <!-- Overrides the stale 2.1.2 pulled transitively via springfox-swagger2 (which
-           doesn't support Schema.requiredMode(), needed by openapi-generator 7.x's
-           generated models). Becomes a direct, non-transitive need once springfox is
-           replaced in Phase 3b. -->
+      <!-- Replaces springfox-swagger2, which was abandoned and broken by Spring MVC's
+           path-matching changes since Boot 2.6, and crashed ld-service at startup with
+           a NullPointerException in documentationPluginsBootstrapper (confirmed via
+           actually running the packaged jar; the service had apparently been unable to
+           start at all for some time). 1.8.0 is the last release on the javax/Boot-2.x
+           line; bumps to the jakarta/Boot-3.x line (springdoc-openapi-starter-webmvc-ui)
+           happen in Phase 3c. Auto-configures itself, no @EnableSwagger2-equivalent
+           annotation needed. -->
+      <dependency>
+          <groupId>org.springdoc</groupId>
+          <artifactId>springdoc-openapi-ui</artifactId>
+          <version>1.8.0</version>
+      </dependency>
+      <!-- Needed directly now that springfox (which pulled in an old 2.1.2 transitively)
+           is gone; current version, supports Schema.requiredMode() used by
+           openapi-generator 7.x's generated models. -->
       <dependency>
           <groupId>io.swagger.core.v3</groupId>
           <artifactId>swagger-annotations</artifactId>

--- a/ld-service/src/main/java/org/nmdp/validation/HLAHapVServiceApplication.java
+++ b/ld-service/src/main/java/org/nmdp/validation/HLAHapVServiceApplication.java
@@ -6,10 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
 @SpringBootApplication
-@EnableSwagger2
 @EnableAutoConfiguration(exclude={DataSourceAutoConfiguration.class,HibernateJpaAutoConfiguration.class})
 public class HLAHapVServiceApplication {
     public static void main(String[] args) {

--- a/ld-service/src/main/java/org/nmdp/validation/controller/GenotypesApiController.java
+++ b/ld-service/src/main/java/org/nmdp/validation/controller/GenotypesApiController.java
@@ -15,7 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.api.GenotypesApi;
 import io.swagger.model.FindingData;
 import io.swagger.model.Genotype;
@@ -27,7 +27,7 @@ import io.swagger.model.Samples;
 @Controller
 public class GenotypesApiController implements GenotypesApi {
     @Override
-    public ResponseEntity<Samples> submitGenotypes(@ApiParam(value = "Genotypes" ,required=true )  @Valid @RequestBody Genotypes genotypes) {
+    public ResponseEntity<Samples> submitGenotypes(@Parameter(description = "Genotypes", required = true)  @Valid @RequestBody Genotypes genotypes) {
         List<Genotype> genotypeList = genotypes.getGenotype();
         Samples samples = new Samples();
         SampleData sampleData = null;

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.enforcer.jdk-version>[${java.version},]</maven.enforcer.jdk-version>
-    <springfox-version>3.0.0</springfox-version>
     <maven.enforcer.maven-version>[3.8.6,)</maven.enforcer.maven-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.targetEncoding>UTF-8</project.build.targetEncoding>
@@ -115,12 +114,6 @@
      <dependency>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-web</artifactId>
-      </dependency>
-      <!--SpringFox dependencies -->
-      <dependency>
-          <groupId>io.springfox</groupId>
-          <artifactId>springfox-swagger2</artifactId>
-          <version>${springfox-version}</version>
       </dependency>
       <!-- Bean Validation API support -->
       <dependency>


### PR DESCRIPTION
Second sub-phase of Phase 3. This one actually fixes a broken service, not just cleanup.

`springfox-swagger2` (declared at the root pom level, inherited by all three modules even though only `ld-service` used it) has been broken by Spring MVC's path-matching changes since Boot 2.6. It crashed `ld-service` at startup with:

```
ApplicationContextException: Failed to start bean 'documentationPluginsBootstrapper';
nested exception is java.lang.NullPointerException: Cannot invoke
"PatternsRequestCondition.getPatterns()" because "this.condition" is null
```

Confirmed in the [Phase 3a PR](https://github.com/mpresteg/ImmunogeneticDataTools/pull/5) that this is pre-existing (identical crash on unmodified `master`) — the service had apparently been unable to start at all for some time.

**Changes:**
- Replaced with `springdoc-openapi-ui` 1.8.0 (last release on the javax/Boot-2.x line; the jakarta/Boot-3.x successor is Phase 3c)
- Moved the dependency from the root pom down into `ld-service/pom.xml` — it's the only module that needs it — and dropped the now-unused `springfox-version` property from root
- Removed `@EnableSwagger2` and its import from `HLAHapVServiceApplication.java` — springdoc auto-configures itself from the classpath
- `GenotypesApiController.java` used `@ApiParam` (Swagger 1.x, arriving transitively via springfox's own `swagger-annotations 1.5.20`), which broke once springfox was removed. Switched to `@Parameter` (OpenAPI 3, `io.swagger.v3.oas.annotations`) instead of pulling the old library back in — matches the OpenAPI 3 tooling already in use everywhere else after Phase 3a.

**Verification:** `mvn clean test` and `mvn package` both pass on JDK 17. More importantly — actually ran the packaged jar (no test coverage exists for this module). It now starts cleanly (`Started HLAHapVServiceApplication in 11.003 seconds`) and serves real requests: `HTTP 200` on both `/swagger-ui/index.html` and `/v3/api-docs`. First time in this investigation the service has come up alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)