### PR TITLE
Phase 3c: migrate to Spring Boot 3.5.16 (javax -> jakarta)

### DIFF
--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -60,18 +60,15 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-web</artifactId>
       </dependency>
-      <!-- Replaces springfox-swagger2, which was abandoned and broken by Spring MVC's
-           path-matching changes since Boot 2.6, and crashed ld-service at startup with
-           a NullPointerException in documentationPluginsBootstrapper (confirmed via
-           actually running the packaged jar; the service had apparently been unable to
-           start at all for some time). 1.8.0 is the last release on the javax/Boot-2.x
-           line; bumps to the jakarta/Boot-3.x line (springdoc-openapi-starter-webmvc-ui)
-           happen in Phase 3c. Auto-configures itself, no @EnableSwagger2-equivalent
-           annotation needed. -->
+      <!-- Replaces springfox-swagger2 (Phase 3b fix for a startup crash), now bumped from
+           the javax/Boot-2.x line (springdoc-openapi-ui) to the jakarta/Boot-3.x
+           successor. 2.9.0 is the latest 2.x release, tracked against Boot 3.x throughout
+           its lifecycle; not jumping to the newer 3.x line yet given how new it is.
+           Auto-configures itself, no annotation needed. -->
       <dependency>
           <groupId>org.springdoc</groupId>
-          <artifactId>springdoc-openapi-ui</artifactId>
-          <version>1.8.0</version>
+          <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+          <version>2.9.0</version>
       </dependency>
       <!-- Needed directly now that springfox (which pulled in an old 2.1.2 transitively)
            is gone; current version, supports Schema.requiredMode() used by
@@ -87,9 +84,11 @@
           <artifactId>jackson-databind-nullable</artifactId>
           <version>0.2.11</version>
       </dependency>
+      <!-- Renamed from mysql:mysql-connector-java (Phase 2 deferred this here: Boot 2.7's
+           BOM didn't manage the new coordinates, Boot 3's does). -->
       <dependency>
-          <groupId>mysql</groupId>
-          <artifactId>mysql-connector-java</artifactId>
+          <groupId>com.mysql</groupId>
+          <artifactId>mysql-connector-j</artifactId>
           <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -100,22 +99,20 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-data-jpa</artifactId>
       </dependency>
-      <!--SpringFox dependencies -->
       <!-- Bean Validation API support -->
       <dependency>
-          <groupId>javax.validation</groupId>
-          <artifactId>validation-api</artifactId>
+          <groupId>jakarta.validation</groupId>
+          <artifactId>jakarta.validation-api</artifactId>
           <scope>provided</scope>
       </dependency>
-        <!-- Version pinned above the Boot 2.7.1 BOM's managed 1.2.11: closes CVE-2023-6378
-             (GHSA-vmq6-5m68-f53m), fixed at 1.2.13, the last release ever made on the 1.2.x
-             line. Later logback CVEs (2024-2026) are only fixed on the 1.3.x/1.5.x lines,
-             which require slf4j-api 2.x, so those are deferred to the Spring Boot 3
-             migration (Phase 3) rather than risking a slf4j 1.x/2.x mismatch under Boot 2.7.1. -->
+        <!-- No version pinned: resolves from the Boot 3.5.16 BOM at 1.5.34, which closes
+             every logback CVE the vulnerability pass had to defer (CVE-2023-6378 was
+             already fixed at 1.2.13; the rest needed slf4j-api 2.x, which Boot 3 provides
+             as part of a tested combination). Matches what Dependabot's PR #115 upstream
+             wanted, done properly here instead of forcing a slf4j mismatch under Boot 2.7. -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -128,7 +125,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.2.13</version>
         </dependency>
   </dependencies>
 
@@ -150,11 +146,12 @@
         </executions>
       </plugin>
              <!--OpenAPI Generator Plugin (replaces the abandoned swagger-codegen-maven-plugin,
-                 last released 2017). Still targeting javax (useJakartaEe=false) to match the
-                 current Boot 2.7.1/javax stack; the jakarta switch happens in Phase 3c
-                 alongside the Spring Boot 3 parent bump. Package names kept identical
-                 (io.swagger.api / io.swagger.model) so GenotypesApiController.java and
-                 HLAHapVServiceApplication.java need no changes.-->
+                 last released 2017). Now targeting jakarta to match the Boot 3 parent
+                 (defaults flipped back to true: useSpringBoot3 defaults true anyway in
+                 7.x and force-enables useJakartaEe regardless of its own setting).
+                 Package names kept identical (io.swagger.api / io.swagger.model) so
+                 GenotypesApiController.java and HLAHapVServiceApplication.java need no
+                 package-import changes beyond the javax->jakarta ones already made.-->
        <plugin>
            <groupId>org.openapitools</groupId>
            <artifactId>openapi-generator-maven-plugin</artifactId>
@@ -174,8 +171,8 @@
                            <sourceFolder>swagger</sourceFolder>
                            <interfaceOnly>true</interfaceOnly>
                            <serializableModel>true</serializableModel>
-                           <useJakartaEe>false</useJakartaEe>
-                           <useSpringBoot3>false</useSpringBoot3>
+                           <useJakartaEe>true</useJakartaEe>
+                           <useSpringBoot3>true</useSpringBoot3>
                        </configOptions>
                    </configuration>
                </execution>

--- a/ld-service/src/main/java/org/nmdp/validation/controller/GenotypesApiController.java
+++ b/ld-service/src/main/java/org/nmdp/validation/controller/GenotypesApiController.java
@@ -3,7 +3,7 @@ package org.nmdp.validation.controller;
 import java.math.BigDecimal;
 import java.util.List;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.dash.valid.LinkageDisequilibriumAnalyzer;
 import org.dash.valid.Sample;

--- a/ld-validation/src/main/java/org/dash/valid/Sample.java
+++ b/ld-validation/src/main/java/org/dash/valid/Sample.java
@@ -3,11 +3,11 @@ package org.dash.valid;
 import org.dash.valid.gl.LinkageDisequilibriumGenotypeList;
 import org.dash.valid.report.DetectedLinkageFindings;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name="sample")
 @XmlType(propOrder={"glString", "findings", "processedGlString"})

--- a/ld-validation/src/main/java/org/dash/valid/gl/haplo/Haplotype.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/haplo/Haplotype.java
@@ -29,10 +29,10 @@ import java.util.Set;
 import org.dash.valid.Locus;
 import org.dash.valid.report.DetectedDisequilibriumElement;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name="haplotype")
 @XmlType(propOrder={"sequence", "haplotypeString"})

--- a/ld-validation/src/main/java/org/dash/valid/gl/haplo/HaplotypePair.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/haplo/HaplotypePair.java
@@ -35,9 +35,9 @@ import org.dash.valid.race.DisequilibriumElementByRace;
 import org.dash.valid.race.FrequencyByRace;
 import org.dash.valid.race.RelativeFrequencyByRace;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name="haplo-pair")
 @XmlType(propOrder={"haplotypes", "frequencies", "frequency"})

--- a/ld-validation/src/main/java/org/dash/valid/race/DisequilibriumElementByRace.java
+++ b/ld-validation/src/main/java/org/dash/valid/race/DisequilibriumElementByRace.java
@@ -29,8 +29,8 @@ import org.dash.valid.CoreDisequilibriumElement;
 import org.dash.valid.Locus;
 import org.dash.valid.gl.GLStringConstants;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="linkage")
 public class DisequilibriumElementByRace extends CoreDisequilibriumElement {

--- a/ld-validation/src/main/java/org/dash/valid/race/RelativeFrequencyByRace.java
+++ b/ld-validation/src/main/java/org/dash/valid/race/RelativeFrequencyByRace.java
@@ -21,10 +21,10 @@
 */
 package org.dash.valid.race;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name="linkage")
 @XmlType(propOrder={"frequency", "relativeFrequency", "hap1Frequency", "hap1Rank", "hap2Frequency", "hap2Rank"})

--- a/ld-validation/src/main/java/org/dash/valid/report/DetectedDisequilibriumElement.java
+++ b/ld-validation/src/main/java/org/dash/valid/report/DetectedDisequilibriumElement.java
@@ -35,10 +35,10 @@ import org.dash.valid.gl.haplo.Haplotype;
 import org.dash.valid.race.DisequilibriumElementByRace;
 import org.dash.valid.race.FrequencyByRace;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 @XmlRootElement(name="linkage")

--- a/ld-validation/src/main/java/org/dash/valid/report/DetectedLinkageFindings.java
+++ b/ld-validation/src/main/java/org/dash/valid/report/DetectedLinkageFindings.java
@@ -42,11 +42,11 @@ import org.dash.valid.race.RelativeFrequencyByRace;
 import org.dash.valid.race.RelativeFrequencyByRaceComparator;
 import org.dash.valid.race.RelativeFrequencyByRaceSet;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 @XmlRootElement(name="gl-freq")

--- a/ld-validation/src/main/java/org/dash/valid/report/SamplesList.java
+++ b/ld-validation/src/main/java/org/dash/valid/report/SamplesList.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import org.dash.valid.Sample;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="samples")
 public class SamplesList {

--- a/ld-validation/src/main/java/org/dash/valid/report/SummaryWriter.java
+++ b/ld-validation/src/main/java/org/dash/valid/report/SummaryWriter.java
@@ -29,9 +29,9 @@ import java.net.URL;
 import java.util.logging.Logger;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.1</version>
+    <version>3.5.16</version>
     <relativePath/>
   </parent>
   <groupId>org.nmdp.validation</groupId>
@@ -117,8 +117,8 @@
       </dependency>
       <!-- Bean Validation API support -->
       <dependency>
-          <groupId>javax.validation</groupId>
-          <artifactId>validation-api</artifactId>
+          <groupId>jakarta.validation</groupId>
+          <artifactId>jakarta.validation-api</artifactId>
           <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Final sub-phase of Phase 3, closing out the Spring Boot 3 migration.

**Changes:**
- Root pom parent: `spring-boot-starter-parent` `2.7.1` → `3.5.16` (current stable; 4.x is still milestone-only)
- `javax.validation:validation-api` → `jakarta.validation:jakarta.validation-api` in the root pom; `javax.validation.Valid` → `jakarta.validation.Valid` in `GenotypesApiController.java`
- 9 files in `ld-validation` (32 import lines) migrated `javax.xml.bind.*` (JAXB) → `jakarta.xml.bind.*` — Boot 3's BOM bumps `glassfish-jaxb` from `2.3.6` (javax) to `4.0.9` (jakarta), so the old imports would stop resolving. Left `javax.xml.parsers`/`javax.xml.validation`/`javax.net.ssl` alone — core JDK APIs, unrelated to the Jakarta EE rename
- `mysql:mysql-connector-java` → `com.mysql:mysql-connector-j` — the deferred Phase 2 item, folded in here since Boot 3's BOM manages the new coordinates
- `springdoc-openapi-ui` 1.8.0 (javax) → `springdoc-openapi-starter-webmvc-ui` 2.9.0 (jakarta) — latest 2.x, not jumping to the very new 3.x line yet
- `openapi-generator-maven-plugin`: `useJakartaEe`/`useSpringBoot3` flipped to `true`
- **Removed the logback version pin (`1.2.13`) added during the vulnerability pass.** Boot 3.5.16's BOM manages logback at `1.5.34` (confirmed via `dependency:tree`), which closes every logback CVE that pass had to defer — needed `slf4j-api 2.x`, which Boot 3 now provides as a tested combination. Also happens to match what Dependabot's upstream PR #115 wanted, done properly here.

**Verification (fixed forward in stages — a change this size breaking all at once wouldn't have been useful signal):**
1. `mvn compile` on the full reactor — clean after the fixes above
2. `mvn clean test` — full suite green, including `AnalyzeGLStringsTest`, which exercises the same JAXB/XML-loading path (fetches IMGT reference XML) now running under `jakarta.xml.bind`
3. `mvn package` + actually running the jar — **failed the first time** with `ClassNotFoundException: ch.qos.logback.core.util.StatusPrinter2` (Boot 3's logging autoconfig expects classes absent from the pinned `1.2.13`). Removing the pin fixed it.
4. Re-ran the packaged jar: starts cleanly (`Started HLAHapVServiceApplication in 8.896 seconds`), `HTTP 200` on both `/swagger-ui/index.html` and `/v3/api-docs`, running on Tomcat 10.1.55/Jakarta Servlet.

This closes out Phase 3 (3a openapi-generator, 3b springdoc-openapi/startup-crash fix, 3c this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)