### PR TITLE
Phase 3.5: streamline Maven dependencies across the reactor

### DIFF
--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -84,21 +84,10 @@
           <artifactId>jackson-databind-nullable</artifactId>
           <version>0.2.11</version>
       </dependency>
-      <!-- Renamed from mysql:mysql-connector-java (Phase 2 deferred this here: Boot 2.7's
-           BOM didn't manage the new coordinates, Boot 3's does). -->
-      <dependency>
-          <groupId>com.mysql</groupId>
-          <artifactId>mysql-connector-j</artifactId>
-          <scope>runtime</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.springframework.data</groupId>
-          <artifactId>spring-data-jpa</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-data-jpa</artifactId>
-      </dependency>
+      <!-- mysql-connector-j, spring-data-jpa, and spring-boot-starter-data-jpa were removed
+           here (Phase 3.5): confirmed unused. HLAHapVServiceApplication explicitly excludes
+           DataSourceAutoConfiguration and HibernateJpaAutoConfiguration, so none of this was
+           ever actually wired up at runtime. Re-add if a real DB feature gets built. -->
       <!-- Bean Validation API support -->
       <dependency>
           <groupId>jakarta.validation</groupId>

--- a/ld-tools/pom.xml
+++ b/ld-tools/pom.xml
@@ -49,18 +49,32 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <!-- guava and dsh-commandline/dsh-compress moved down from the root pom (Phase 3.5),
+       used directly here (About.java, AnalyzeGLStrings.java, NormalizeFrequencyFile.java).
+       ngs-hml removed: confirmed zero usage anywhere despite being declared both here and
+       at the root. HML file support is real (in ld-validation's GLStringUtilities) but
+       implemented via generic DOM parsing, never used ngs-hml's JAXB classes. -->
   <dependencies>
       <dependency>
         <groupId>org.nmdp.validation</groupId>
         <artifactId>ld-validation</artifactId>
         <scope>compile</scope>
       </dependency>
-     <dependency>
-      <groupId>org.nmdp.ngs</groupId>
-      <artifactId>ngs-hml</artifactId>
-      <version>1.8.3</version>
-      <scope>compile</scope>
-    </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.7.1-jre</version>
+      </dependency>
+      <dependency>
+        <groupId>org.dishevelled</groupId>
+        <artifactId>dsh-commandline</artifactId>
+        <version>1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.dishevelled</groupId>
+        <artifactId>dsh-compress</artifactId>
+        <version>1.6</version>
+      </dependency>
   </dependencies>
 
 

--- a/ld-validation/pom.xml
+++ b/ld-validation/pom.xml
@@ -39,7 +39,40 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.targetEncoding>UTF-8</project.build.targetEncoding>
   </properties>
-  
+
+  <!-- Moved down from the root pom (Phase 3.5): these were previously inherited by
+       every module regardless of need. poi/poi-ooxml and jaxb-runtime/jakarta.xml.bind-api
+       are used directly here (frequency file parsing, JAXB annotations on Sample/
+       Haplotype/etc.); commons-lang was riding a transitive freebie via dsh-commandline,
+       which now lives in ld-tools instead, so it's declared explicitly here since
+       GLStringUtilities.java uses it directly. -->
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.poi</groupId>
+      <artifactId>poi</artifactId>
+      <version>5.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.poi</groupId>
+      <artifactId>poi-ooxml</artifactId>
+      <version>5.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <testSourceDirectory>src/test/java</testSourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -75,66 +75,19 @@
   		</plugins>
   	</pluginManagement>
  </build>
+  <!-- Only genuinely shared dependencies live here. Module-specific dependencies
+       (guava, poi, dsh-commandline/dsh-compress, jaxb-runtime, spring-boot-starter-web,
+       jakarta.validation-api) moved down to whichever module actually uses them, see
+       Phase 3.5 in the modernization plan. Also removed here: ngs-hml (confirmed zero
+       usage anywhere; HML file support is real, in GLStringUtilities, but implemented
+       via generic DOM parsing, never used ngs-hml's JAXB classes) and log4j-core/
+       log4j-api (zero direct usage anywhere in the reactor: ld-tools/ld-validation log
+       via java.util.logging, ld-service via logback). -->
   <dependencies>
-  	<dependency>
-  		<groupId>com.google.guava</groupId>
-  		<artifactId>guava</artifactId>
-  		<version>33.7.1-jre</version>
-  	</dependency>
-  	<!-- API, java.xml.bind module -->
-	<dependency>
-		<groupId>org.glassfish.jaxb</groupId>
-		<artifactId>jaxb-runtime</artifactId>
-	</dependency>
-  	<dependency>
-  		<groupId>org.apache.poi</groupId>
-  		<artifactId>poi-ooxml</artifactId>
-  		<version>5.5.1</version>
-  	</dependency>
-  	<dependency>
-  		<groupId>org.apache.poi</groupId>
-  		<artifactId>poi</artifactId>
-  		<version>5.5.1</version>
-  	</dependency>
-      <dependency>
-        <groupId>org.dishevelled</groupId>
-        <artifactId>dsh-commandline</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.dishevelled</groupId>
-        <artifactId>dsh-compress</artifactId>
-        <version>1.6</version>
-      </dependency>
-     <dependency>
-      <groupId>org.nmdp.ngs</groupId>
-      <artifactId>ngs-hml</artifactId>
-      <version>1.8.3</version>
-    </dependency>
-     <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-web</artifactId>
-      </dependency>
-      <!-- Bean Validation API support -->
-      <dependency>
-          <groupId>jakarta.validation</groupId>
-          <artifactId>jakarta.validation-api</artifactId>
-          <scope>provided</scope>
-      </dependency>
       <dependency>
       	<groupId>org.junit.jupiter</groupId>
       	<artifactId>junit-jupiter-api</artifactId>
       </dependency>
-      <dependency>
-      	<groupId>org.apache.logging.log4j</groupId>
-      	<artifactId>log4j-core</artifactId>
-      </dependency>
-
-            <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-            </dependency>
   </dependencies>
 
   <description>Tools for exploring Linkage Disequilibrium, HLA, GL Strings</description>


### PR DESCRIPTION
Scoped with real evidence — grep for actual import usage per module, cross-checked against `mvn dependency:analyze`, rather than guessing.

**Moved from the root pom** (previously inherited by every module regardless of need) down to whichever module actually uses them:
- `guava`, `dsh-commandline`, `dsh-compress` → `ld-tools`
- `poi`, `poi-ooxml` → `ld-validation`
- `jaxb-runtime`, `jakarta.xml.bind-api` → `ld-validation`
- `spring-boot-starter-web`, `jakarta.validation-api` → removed redundant root copies (already directly declared in `ld-service`)

Also added an explicit `commons-lang:commons-lang:2.6` to `ld-validation` — `GLStringUtilities.java` uses it directly but it was undeclared, riding a transitive freebie via `dsh-commandline`, which just moved out of `ld-validation`'s classpath entirely. Would have broken silently without this.

**Removed entirely** (each investigated, not just deleted on a tool's say-so):
- `log4j-core`/`log4j-api` — zero direct usage anywhere in the reactor
- `ngs-hml` — zero usage anywhere, despite the README documenting HML 1.x support. **Investigated before removing:** HML support is real and tested (`testHMLFile()` passes), just implemented via generic DOM parsing rather than `ngs-hml`'s JAXB classes. No functionality gap, just unused cruft dating to 2016.
- `mysql-connector-j`, `spring-data-jpa`, `spring-boot-starter-data-jpa` in `ld-service` — confirmed unused twice now; `HLAHapVServiceApplication` explicitly excludes the autoconfiguration that would wire them up.

**Verification:** `mvn clean compile` and `mvn clean test` both pass on the full reactor (including `testHMLFile`, confirming HML support is genuinely unaffected). Packaged and ran the jar again — starts cleanly in 10.9s, `HTTP 200` on `/swagger-ui/index.html` and `/v3/api-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)