### PR TITLE
Phase 4b: reject pathologically ambiguous genotypes; fix silent multi-gene phasing corruption

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/gl/AmbiguousGenotypeException.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/AmbiguousGenotypeException.java
@@ -1,0 +1,39 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.gl;
+
+/**
+ * Thrown when a genotype's allele or protein ambiguity at a locus exceeds the
+ * configured threshold (org.dash.ambThreshold / org.dash.proteinThreshold),
+ * making full haplotype-pair enumeration (a cartesian product across every
+ * ambiguous allele at every locus in a linkage set) computationally
+ * infeasible. Unchecked: callers that process many genotypes (e.g. a batch
+ * file) should catch this per-genotype and continue with the rest of the
+ * batch, rather than letting one pathological entry abort the whole run.
+ */
+public class AmbiguousGenotypeException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+
+	public AmbiguousGenotypeException(String message) {
+		super(message);
+	}
+}

--- a/ld-validation/src/main/java/org/dash/valid/gl/GLStringUtilities.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/GLStringUtilities.java
@@ -539,7 +539,12 @@ public class GLStringUtilities {
 		    		glString.append(glValue);
 		    	}
 		    	
-		    	linkedGLStrings.add(inflateGenotypeList(sampleId, glString.toString(), null));
+		    	try {
+		    		linkedGLStrings.add(inflateGenotypeList(sampleId, glString.toString(), null));
+		    	}
+		    	catch (AmbiguousGenotypeException e) {
+		    		LOGGER.warning("Skipping id: " + sampleId + " in " + filename + " -- " + e.getMessage());
+		    	}
 		    }
 		}
 		else {
@@ -571,8 +576,14 @@ public class GLStringUtilities {
 					continue;
 				}
 				
-				linkedGLStrings.add(inflateGenotypeList(id, glString, note));
-					
+				try {
+					linkedGLStrings.add(inflateGenotypeList(id, glString, note));
+				}
+				catch (AmbiguousGenotypeException e) {
+					LOGGER.warning("Skipping id: " + id + " at line " + (lineNumber - 1)
+							+ " in " + filename + " -- " + e.getMessage());
+				}
+
 			}
 		}
 				

--- a/ld-validation/src/main/java/org/dash/valid/gl/LinkageDisequilibriumGenotypeList.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/LinkageDisequilibriumGenotypeList.java
@@ -167,7 +167,7 @@ public class LinkageDisequilibriumGenotypeList {
 							+ locus.getFullName());
 					return false;
 				}
-	
+
 				if (getProteinCount(locus) > PROTEIN_THRESHOLD) {
 					LOGGER.warning("Exceeded the protein threshold of : "
 							+ PROTEIN_THRESHOLD + " at locus: "
@@ -178,6 +178,32 @@ public class LinkageDisequilibriumGenotypeList {
 		}
 
 		return true;
+	}
+
+	// Guards constructPossibleHaplotypes() before it computes a cartesian product across
+	// every ambiguous allele at every locus in loci: for a genuinely ambiguous genotype
+	// (e.g. from shallow/low-resolution NGS typing), that product can reach into the
+	// billions and effectively hang. checkAmbiguitiesThresholds() above already detects
+	// this same condition but only logs a warning and lets processing continue anyway --
+	// this throws instead, so the expensive computation never starts.
+	private void checkAmbiguityThresholds(Set<Locus> loci) {
+		for (Locus locus : loci) {
+			int alleleCount = getAlleleCount(locus);
+			if (alleleCount > ALLELE_AMBIGUITY_THRESHOLD) {
+				throw new AmbiguousGenotypeException("GL string " + id + " has " + alleleCount
+						+ " ambiguous alleles at locus " + locus.getFullName()
+						+ ", exceeding the allele ambiguity threshold of " + ALLELE_AMBIGUITY_THRESHOLD
+						+ " (adjust with -Dorg.dash.ambThreshold). Too ambiguous to enumerate possible haplotypes.");
+			}
+
+			int proteinCount = getProteinCount(locus);
+			if (proteinCount > PROTEIN_THRESHOLD) {
+				throw new AmbiguousGenotypeException("GL string " + id + " has " + proteinCount
+						+ " distinct proteins at locus " + locus.getFullName()
+						+ ", exceeding the protein threshold of " + PROTEIN_THRESHOLD
+						+ " (adjust with -Dorg.dash.proteinThreshold). Too ambiguous to enumerate possible haplotypes.");
+			}
+		}
 	}
 
 	public int getAlleleCount(Locus locus) {
@@ -202,17 +228,21 @@ public class LinkageDisequilibriumGenotypeList {
 		return proteins.size();
 	}
 
+	// Locus is derived per genePhase (the innermost, actual allele-bearing segment --
+	// each one carries its own "HLA-X*..." locus prefix), not once per outer ^-delimited
+	// gene block. Per the GL String spec (Milius et al., PMC3715123), ^ separates loci
+	// in an *unphased* multilocus genotype, while ~ ("phased genes" in the spec's own
+	// delimiter table) phases alleles across genes -- a fully phased genotype can
+	// legitimately have zero ^ characters at all, chaining every gene with ~ instead.
+	// Deriving locus from the outer gene block meant that case silently collapsed every
+	// gene's alleles onto whichever locus was named first in the string, with no error.
 	private void parseGLString() {
 		HashMap<String, Locus> locusMap = new HashMap<String, Locus>();
 		Locus locus = null;
-		
+
 		List<String> genes = GLStringUtilities.parse(glString,
 				GLStringConstants.GENE_DELIMITER);
 		for (String gene : genes) {
-			String[] splitString = gene
-					.split(GLStringUtilities.ESCAPED_ASTERISK);
-			String locusVal = splitString[0];
-
 			List<String> genotypeAmbiguities = GLStringUtilities.parse(gene,
 					GLStringConstants.GENOTYPE_AMBIGUITY_DELIMITER);
 			for (String genotypeAmbiguity : genotypeAmbiguities) {
@@ -223,10 +253,14 @@ public class LinkageDisequilibriumGenotypeList {
 					List<String> genePhases = GLStringUtilities.parse(geneCopy,
 							GLStringConstants.GENE_PHASE_DELIMITER);
 					for (String genePhase : genePhases) {
+						String[] splitString = genePhase
+								.split(GLStringUtilities.ESCAPED_ASTERISK);
+						String locusVal = splitString[0];
+
 						List<String> alleleAmbiguities = GLStringUtilities
 								.parse(genePhase,
 										GLStringConstants.ALLELE_AMBIGUITY_DELIMITER);
-						
+
 						if (locusMap.containsKey(locusVal)) {
 							locus = locusMap.get(locusVal);
 						}
@@ -318,6 +352,8 @@ public class LinkageDisequilibriumGenotypeList {
 
 	@SuppressWarnings("unchecked")
 	public Set<MultiLocusHaplotype> constructPossibleHaplotypes(Set<Locus> loci) {
+		checkAmbiguityThresholds(loci);
+
 		HashMap<Locus, SingleLocusHaplotype> singleLocusHaplotypes = new HashMap<Locus, SingleLocusHaplotype>();
 		Set<MultiLocusHaplotype> possibleHaplotypes = new HashSet<MultiLocusHaplotype>();
 


### PR DESCRIPTION
**Root cause** (from a real 32,757-char GL string, `stanfordExamplesFixed.txt` line 156): `HLALinkageDisequilibrium.findLinkedPairs()` enumerates every possible haplotype via a cartesian product across every ambiguous allele at every locus in a linkage set. That genotype has 1,595 ambiguous alleles per side at `HLA-C` alone (2.5M+ single-locus combinations before considering other loci) — no algorithmic tweak fixes that; it's inherent to enumerating haplotypes from a genotype this ambiguous (consistent with shallow/low-resolution NGS typing).

**Fix** (reject with a clear error, chosen over cap-and-warn or documenting-as-a-limitation):
- Added `AmbiguousGenotypeException` (unchecked)
- `constructPossibleHaplotypes()` now checks allele/protein counts per locus *before* computing the cartesian product — reusing the existing (but previously unenforced) `ALLELE_AMBIGUITY_THRESHOLD`/`PROTEIN_THRESHOLD` constants and `getAlleleCount()`/`getProteinCount()` that `checkAmbiguitiesThresholds()` already used for an advisory-only log message. Throws immediately instead of proceeding into the expensive computation.
- `GLStringUtilities.parseGLStringFile()` catches this per-GL-string (both the delimited-file loop and the XML/HML sample loop) and skips/logs rather than aborting the whole batch run.

**Separate, more serious bug found and fixed along the way.** Verified against the actual published GL String spec (Milius et al., PMC3715123) that `^` separates loci only for *unphased* multilocus genotypes, while `~` is documented as "phased genes" — a fully phased genotype can legitimately chain every gene with `~` alone, no `^` at all. `parseGLString()` derived locus once per `^`-delimited block rather than per inner phased segment, so an all-`~`-no-`^` multi-gene genotype silently collapsed every gene's alleles onto whichever locus was named first — no error, just wrong data.

Confirmed via direct inspection that `testPhasedGenotypeList`'s 9-locus phased fixture ended up with all 21 allele entries bucketed under `HLA-A` alone and every other locus empty. The test only asserted non-null on the resulting `Sample`, so this went undetected since the test was added in 2017 (the bug itself dates to the class's creation in 2015). Fixed by deriving locus per `genePhase` segment instead of per outer `gene` block — verified all 9 loci now populate correctly (2–3 alleles each, matching the actual input) rather than 21 on `HLA-A` and 0 everywhere else.

**Verification:**
- `mvn clean test` passes (32/32), including `testPhasedGenotypeList` now passing against genuinely correct parsed data rather than corrupted data that happened not to crash
- Ran the actual pathological line 156 end-to-end: rejects in 1.6s with a clear message naming the offending locus (`HLA-C`, 3190 alleles vs threshold 20) instead of hanging indefinitely; batch run completes normally with the one line skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)