### PR TITLE
Phase 4d: add log4j-core back as runtime-only to silence POI's provider warning

### DIFF
--- a/ld-validation/pom.xml
+++ b/ld-validation/pom.xml
@@ -57,6 +57,18 @@
       <artifactId>poi-ooxml</artifactId>
       <version>5.5.1</version>
     </dependency>
+    <!-- Phase 4d: POI itself pulls in log4j-api transitively for its own internal logging.
+         Phase 3.5 removed our direct log4j-core/log4j-api dependency since nothing in our
+         own code uses log4j, and that's still true, but doing so also removed the provider
+         POI's internal log4j-api calls need, so log4j-api now prints its own cosmetic
+         "could not find a logging provider" message at startup. Never a functional problem
+         (log4j-api falls back to a no-op logger), just noisy. Adding log4j-core back as
+         runtime-only satisfies POI's lookup without our own code ever importing it. -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>


### PR DESCRIPTION
\`mvn install\` (and anything touching Apache POI) prints:
\`\`\`
ERROR Log4j API could not find a logging provider.
\`\`\`

**Root cause:** Apache POI 5.5.1 pulls in \`log4j-api\` transitively for its own internal logging. Phase 3.5 removed our direct \`log4j-core\`/\`log4j-api\` dependency since nothing in our own code uses log4j (still true) — but that also removed the provider POI's internal log4j-api calls were binding to, so log4j-api now falls through to its own self-diagnostic warning at startup. **Never a functional problem** (log4j-api falls back to a no-op logger internally — confirmed by every build/test run across this whole session succeeding regardless), just noisy/alarming-looking output.

**Fix:** added \`log4j-core\` back to \`ld-validation\` (where POI now lives, since Phase 3.5) as a **runtime-scoped** dependency — gives POI's lookup a real provider without our own code ever importing log4j directly. No version pinned, resolves from the Boot 3.5.16 BOM.

**Verification:** \`mvn clean install\` no longer prints the warning; \`mvn clean test\` passes on the full reactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)