### PR TITLE
Phase 4c: fix O(n) scan and uncached regex in the hot analysis path

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/gl/GLStringUtilities.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/GLStringUtilities.java
@@ -65,6 +65,9 @@ public class GLStringUtilities {
 	private static final String FILE_DELIMITER_REGEX = "[\t,]";
 	public static final String ESCAPED_ASTERISK = "\\*";
 	public static final String VARIANTS_REGEX = "[SNLQ]";
+	// Precompiled once instead of via Pattern.matches(), which recompiles the regex from
+	// scratch on every call -- convertToProteinLevel() is on the hot analysis path.
+	private static final Pattern VARIANTS_PATTERN = Pattern.compile(VARIANTS_REGEX);
 	public static final String COLON = ":";
 	public static final int P_GROUP_LEVEL = 2;
 
@@ -358,16 +361,13 @@ public class GLStringUtilities {
 		
 		HashMap<String, HashSet<String>> arsMap = instance.getArsMap();
 
-		if (arsMap.containsKey(referenceAllele)) {
-			for (String arsCode : arsMap.keySet()) {
-				if (arsCode.equals(referenceAllele)
-						&& arsMap.get(arsCode).contains(matchedValue)) {
-					return true;
-				}
-			}
-		}
-
-		return false;
+		// Was: containsKey(referenceAllele) followed by a full keySet() scan doing its own
+		// manual .equals() to re-find the same key -- an O(n) scan over the whole map on
+		// every call, in place of the O(1) get() already sitting right there. Profiled as
+		// ~41% of total CPU time (plus another ~16% in the keySet() iterator itself) on a
+		// real batch run -- this was the single largest hot spot in the analysis path.
+		HashSet<String> arsCodes = arsMap.get(referenceAllele);
+		return arsCodes != null && arsCodes.contains(matchedValue);
 	}
 
 	public static String convertToProteinLevel(String allele) {
@@ -375,8 +375,8 @@ public class GLStringUtilities {
 
 		String matchedValue = null;
 		if (parts.length > P_GROUP_LEVEL
-				&& Pattern.matches(VARIANTS_REGEX,
-						"" + allele.charAt(allele.length() - 1))) {
+				&& VARIANTS_PATTERN.matcher(
+						"" + allele.charAt(allele.length() - 1)).matches()) {
 			matchedValue = parts[0] + COLON + parts[1]
 					+ allele.charAt(allele.length() - 1);
 			LOGGER.finest("Found an SNLQ while comparing ARS: " + allele);


### PR DESCRIPTION
Profiled a real batch run (JDK Flight Recorder, full \`stanfordExamplesFixed.txt\`, 331 GL strings) rather than guessing. Two clear hot spots:

**\`checkAntigenRecognitionSite()\`: 40.8% of all CPU samples.** Did \`arsMap.containsKey(referenceAllele)\` — an O(1) check — then threw that away and re-scanned the *entire* map's \`keySet()\` doing a manual \`.equals()\` to re-find the same key. An O(n) scan on every call, in place of the O(1) \`get()\` already sitting right there. Called from \`DisequilibriumElement.equals()\`, itself called from \`ArrayList.contains()\`/\`.indexOf()\` inside the core pairing loop — explains why \`HashMap$HashIterator.nextNode()\` was *separately* 15.9% of all samples (the \`keySet()\` iteration). **Fixed:** \`arsMap.get(referenceAllele)\` directly — functionally identical, O(1) instead of O(n).

**\`convertToProteinLevel()\`:** used \`Pattern.matches()\`, which recompiles the regex from scratch on every call. ~5% combined in \`Pattern.compile()\`/\`Pattern.<init>()\`. **Fixed:** precompiled \`Pattern\`, reused via \`.matcher().matches()\`.

**Measured impact:** same full-file batch run, clean rebuild each side — wall clock **45.65s → 31.80s, ~30% faster**. (Wall clock understates the CPU-time win since it includes network download time for reference XML, which the fix doesn't touch.)

**Verified behaviorally identical, not just "tests still pass":** ran the full batch through both versions and diffed \`summary.xml\` content (order-independent, since Set-based output ordering isn't guaranteed stable). Found 5/331 samples differing — traced this to a **pre-existing bug, not something this fix touches**: ran the *unfixed* code twice back-to-back and got the same 5 sample IDs differing by the same magnitude (823 vs 818 total haplotype-pair entries) against itself. \`HaplotypePairComparator.compare()\` starts with \`element1.equals(element2)\` to decide duplicates; the algorithm generates both \`(A,B)\` and \`(B,A)\` orderings from an unordered \`HashSet\` iteration, so if \`HaplotypePair.equals()\` isn't properly symmetric, dedup outcome depends on encounter order, which varies between JVM runs. **Not fixed here** — separate, real correctness bug, flagged for its own investigation.

**Verification:** \`mvn clean test\` passes (32/32) on the full reactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)