### PR TITLE
Fix Haplotype/HaplotypePair equals()/hashCode() contract violations

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/gl/haplo/Haplotype.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/haplo/Haplotype.java
@@ -82,14 +82,33 @@ public abstract class Haplotype {
 		return getHaplotypeString();
 	}
 	
+	// Was: required getHaplotypeInstances() to match (a List<Integer> built from
+	// HashMap<Locus, Integer>.values() -- unordered, so List.equals() on it varies with
+	// hash-bucket iteration order, itself not guaranteed stable across JVM runs since
+	// Locus enum constants use identity hashCode); getAlleles().containsAll() (asymmetric
+	// -- true if this's list is a superset of the other's, not mutual containment); and a
+	// getLinkage() check that returned true whenever *this* object's linkage was null,
+	// regardless of the other side's linkage (also asymmetric). All three meant
+	// haplotype1.equals(haplotype2) could disagree with haplotype2.equals(haplotype1), and
+	// results depended on HashSet iteration order -- which varies run to run. Confirmed via
+	// running the same input twice and diffing output: identical code, different results.
+	//
+	// getHaplotypeString() is already the canonical, order-stable representation (built via
+	// LocusSet/LocusComparator, not raw HashMap iteration) -- it alone is sufficient and
+	// gives a properly symmetric, deterministic equals()/hashCode() pair.
 	@Override
-	public boolean equals(Object element1) {		
-		if (getHaplotypeInstances().equals(((Haplotype) element1).getHaplotypeInstances()) && getAlleles().containsAll(((Haplotype) element1).getAlleles()) &&
-				getHaplotypeString().equals(((Haplotype) element1).getHaplotypeString()) && 
-				(getLinkage() == null || (getLinkage() != null && getLinkage().equals(((Haplotype) element1).getLinkage())))) {
+	public boolean equals(Object obj) {
+		if (this == obj) {
 			return true;
 		}
-		
-		return false;
+		if (!(obj instanceof Haplotype)) {
+			return false;
+		}
+		return getHaplotypeString().equals(((Haplotype) obj).getHaplotypeString());
+	}
+
+	@Override
+	public int hashCode() {
+		return getHaplotypeString().hashCode();
 	}
 }

--- a/ld-validation/src/main/java/org/dash/valid/gl/haplo/HaplotypePair.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/haplo/HaplotypePair.java
@@ -153,14 +153,23 @@ public class HaplotypePair {
 		if (haplotypePair == null) {
 			return false;
 		}
-		else if ((haplotypes.get(0).equals(((HaplotypePair) haplotypePair).haplotypes.get(0)) && 
+		else if ((haplotypes.get(0).equals(((HaplotypePair) haplotypePair).haplotypes.get(0)) &&
 				haplotypes.get(1).equals(((HaplotypePair) haplotypePair).haplotypes.get(1))) ||
-				(haplotypes.get(0).equals(((HaplotypePair) haplotypePair).haplotypes.get(1)) && 
+				(haplotypes.get(0).equals(((HaplotypePair) haplotypePair).haplotypes.get(1)) &&
 				haplotypes.get(1).equals(((HaplotypePair) haplotypePair).haplotypes.get(0)))) {
 			return true;
 		}
-		
+
 		return false;
+	}
+
+	// Was missing entirely -- HaplotypePair overrode equals() but not hashCode(), breaking
+	// contract for any HashSet/HashMap usage (e.g. DetectedLinkageFindings' noRaceOverlapPairs).
+	// Order-independent (sum, not concatenation) since equals() above accepts either
+	// (hap1,hap2) or (hap2,hap1) ordering as equal.
+	@Override
+	public int hashCode() {
+		return haplotypes.get(0).hashCode() + haplotypes.get(1).hashCode();
 	}
 	
 	@Override


### PR DESCRIPTION
Real, verified bugs, found while investigating the run-to-run non-determinism discovered during Phase 4c: identical input, run twice, gave different haplotype-pair results (823 vs 818 total entries, 5/331 samples differing).

**`Haplotype.equals()` had three independent asymmetries:**
- `getHaplotypeInstances()` built a `List<Integer>` from `HashMap<Locus, Integer>.values()` — unordered, and `List.equals()` on it is order-sensitive, so it could disagree with itself across two logically-identical objects depending on `HashMap` iteration order (itself not guaranteed stable across JVM runs, since `Locus` enum constants use identity hashCode)
- `getAlleles().containsAll(other.getAlleles())` is asymmetric: true if this's list is a superset of the other's, not mutual containment
- The linkage check returned true whenever *this* object's linkage was null, regardless of the other side's — also asymmetric

**Second bug:** neither `Haplotype` nor `HaplotypePair` overrode `hashCode()` at all, despite both overriding `equals()`. `HashSet<MultiLocusHaplotype>` (`linkedHaplotypes` in `HLALinkageDisequilibrium.findLinkedPairs()`) and `HashSet<HaplotypePair>` (`DetectedLinkageFindings.noRaceOverlapPairs`) both fell back to identity hashCode, which HotSpot assigns per JVM launch and doesn't guarantee stability across separate runs.

**Fix:** `Haplotype.equals()`/`hashCode()` now both derive solely from `getHaplotypeString()`, which is already a canonical, order-stable representation (built via `LocusSet`/`LocusComparator`, not raw `HashMap` iteration) — properly symmetric and consistent by construction. Added `HaplotypePair.hashCode()`, order-independent (sum of both haplotypes' hashCodes) since its `equals()` already accepts either ordering.

**Verification:** `mvn clean test` passes (32/32). Re-ran the same run-twice-and-diff-`summary.xml` determinism check used to find the bug: **total haplotype-pair count is now stable (819 == 819 across two runs, vs. 823/818 before)** — the equals/hashCode fix is real and working.

**Important — full determinism is NOT yet achieved.** 7/331 samples still differ in which *specific* haplotype pairs get reported (same count, different content), pointing to a separate, deeper issue: when multiple candidate haplotypes are equally biologically valid (tied), selection depends on `HashSet<MultiLocusHaplotype>` iteration order in `constructPossibleHaplotypes()` (built from a cartesian product), with no defined tie-breaking rule. That's a genuinely bigger design question — what should the tie-breaking rule even be? — scoped separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)