### PR TITLE
Generalize NormalizeFrequencyFile to any locus combination, stream XLSX reads

### DIFF
--- a/ld-tools/pom.xml
+++ b/ld-tools/pom.xml
@@ -75,6 +75,22 @@
         <artifactId>dsh-compress</artifactId>
         <version>1.6</version>
       </dependency>
+      <!-- dsh-compress transitively pulls commons-compress 1.21, which wins Maven's "nearest
+           wins" resolution over poi-ooxml's own required commons-compress version (a deeper
+           transitive dependency via ld-validation), since dsh-compress is declared directly
+           here. This didn't used to matter: poi-ooxml 5.2.2 (in use before this project's
+           Phase 1 dependency bump) itself required exactly commons-compress 1.21, so the two
+           agreed by coincidence. Bumping poi/poi-ooxml to 5.5.1 raised POI's own requirement
+           to commons-compress 1.28.0 without touching dsh-compress's transitive 1.21, so the
+           two now disagree, and NormalizeFrequencyFile breaks with NoSuchMethodError
+           (ZipArchiveInputStream.getNextEntry() changed signature between those versions) the
+           first time it actually reads an XLSX file. A regression from that POI bump, not a
+           pre-existing bug. Declaring the version POI 5.5.1 actually needs directly overrides it. -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.28.0</version>
+      </dependency>
   </dependencies>
 
 

--- a/ld-tools/src/main/java/org/nmdp/validation/tools/NormalizeFrequencyFile.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/NormalizeFrequencyFile.java
@@ -24,17 +24,10 @@ package org.nmdp.validation.tools;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.PrintWriter;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.dash.valid.DisequilibriumElement;
-import org.dash.valid.Linkages;
-import org.dash.valid.LinkagesLoader;
 import org.dash.valid.Locus;
 import org.dash.valid.freq.HLAFrequenciesLoader;
 import org.dash.valid.gl.GLStringConstants;
@@ -54,23 +47,12 @@ import org.dishevelled.commandline.argument.StringArgument;
  *
  */
 public class NormalizeFrequencyFile implements Callable<Integer> {
-	
+
     private final File inputFile;
     private final String frequencies;
     private final File outputFile;
-    
+
     public static final String SINGLE = "single";
-    
-    private static Map<EnumSet<Locus>, Locus[]> LOCUS_POSITION_MAP = new HashMap<EnumSet<Locus>, Locus[]>();
-    
-    static {
-    	LOCUS_POSITION_MAP.put(Locus.A_C_B_LOCI, HLAFrequenciesLoader.NMDP_ABC_LOCI_POS);
-    	LOCUS_POSITION_MAP.put(Locus.C_B_LOCI, HLAFrequenciesLoader.NMDP_BC_LOCI_POS);
-    	LOCUS_POSITION_MAP.put(Locus.DRB1_DQB1_LOCI, HLAFrequenciesLoader.NMDP_DRB1DQB1_LOCI_POS);
-    	LOCUS_POSITION_MAP.put(Locus.DRB_DQB_LOCI, HLAFrequenciesLoader.NMDP_DRDQB1_LOCI_POS);
-    	LOCUS_POSITION_MAP.put(Locus.FIVE_LOCUS, HLAFrequenciesLoader.NMDP_FIVE_LOCUS_POS);
-    	LOCUS_POSITION_MAP.put(Locus.SIX_LOCUS, HLAFrequenciesLoader.NMDP_SIX_LOCUS_POS);
-    }
 
     private static final String USAGE = "normalize-frequency-file [args]";
 
@@ -89,6 +71,13 @@ public class NormalizeFrequencyFile implements Callable<Integer> {
     
     @Override
     public Integer call() throws Exception {
+    	// POI's default 100MB cap on a single in-memory array allocation (a zip-bomb guard) is
+    	// too small for some of the larger reference files this tool is meant to read (the
+    	// nine-locus NMDP release's biggest files run well past that once decompressed); this
+    	// tool only ever reads a file the caller names directly on the local filesystem, never
+    	// an untrusted upload, so raising the cap here is safe.
+    	org.apache.poi.util.IOUtils.setByteArrayMaxOverride(Integer.MAX_VALUE);
+
     	PrintWriter writer = new PrintWriter(outputFile);
     	
     	if (SINGLE.equals(frequencies)) {
@@ -99,17 +88,28 @@ public class NormalizeFrequencyFile implements Callable<Integer> {
     		}
     	}
     	else {
-			HashSet<String> linkageNames = new HashSet<String>();
-			linkageNames.add(frequencies);
-			Set<Linkages> linkagesSet = Linkages.lookup(linkageNames);
-			LinkagesLoader.getInstance(linkagesSet);
-									
-			List<DisequilibriumElement> disequilibriumElements = HLAFrequenciesLoader.loadNMDPLinkageReferenceData(new FileInputStream(inputFile), LOCUS_POSITION_MAP.get(Linkages.lookup(frequencies).getLoci()));
-					
+			// Was: a hardcoded Map<EnumSet<Locus>, Locus[]> keyed by a pre-registered Linkages
+			// enum constant, so adding support for a new locus combination meant adding new
+			// Linkages/Locus.*_LOCI constants first. This project's own bundled reference files
+			// (frequencies/nmdp/A~C~B.xlsx, .../DRB3-4-5~DRB1~DQB1.xlsx, etc.) already name
+			// themselves with their exact column order, "~"-joined -- Locus.lookup() already
+			// resolves every token that convention uses (including "DRBX" and "DRB3-4-5" as
+			// DRB345 aliases), so deriving column order directly from the input file's own name
+			// handles any locus combination a reference file happens to be named for, without
+			// needing new enum constants registered ahead of time for each one.
+			Locus[] locusPositions = deriveLocusPositions(inputFile);
+
+			List<DisequilibriumElement> disequilibriumElements = HLAFrequenciesLoader.loadNMDPLinkageReferenceData(new FileInputStream(inputFile), locusPositions);
+
 			for (DisequilibriumElement element : disequilibriumElements) {
 				StringBuffer sb = new StringBuffer();
 				int locusCounter = 0;
-				for (Locus locus : Locus.lookup(element.getLoci())) {
+				// Was: Locus.lookup(element.getLoci()) -- looks up the exact locus SET against
+				// the same small set of pre-registered combos, returning null (NPE on iteration)
+				// for anything else. locusPositions is already the correct, file-derived order
+				// for these exact elements (it's what they were just loaded with), so use it
+				// directly instead of re-deriving order through that same limited lookup.
+				for (Locus locus : locusPositions) {
 					if (locusCounter > 0) {
 						sb.append(GLStringConstants.GENE_PHASE_DELIMITER);
 					}
@@ -126,9 +126,36 @@ public class NormalizeFrequencyFile implements Callable<Integer> {
     	}
     	
     	writer.close();
-    	
+
     	return 0;
-	}    	
+	}
+
+	// Derives the per-column Locus order from the input file's own name: "A~C~B.xlsx" ->
+	// [HLA_A, HLA_C, HLA_B]. Matches the naming convention this project's own bundled
+	// frequencies/nmdp/*.xlsx files already use (including "DRB3-4-5", which Locus.lookup()
+	// already resolves via its freqName field), so newer NMDP reference file releases that
+	// follow the same convention (e.g. the 2026 nine-locus release's "DRBX~DRB1~DQA1~DQB1.xlsx")
+	// work without any code change here, as long as every "~"-joined token is a locus
+	// Locus.lookup() recognizes.
+	private static Locus[] deriveLocusPositions(File file) {
+		String baseName = file.getName();
+		int dot = baseName.lastIndexOf('.');
+		String stem = dot > 0 ? baseName.substring(0, dot) : baseName;
+		String[] tokens = stem.split(GLStringConstants.GENE_PHASE_DELIMITER);
+
+		Locus[] positions = new Locus[tokens.length];
+		for (int i = 0; i < tokens.length; i++) {
+			Locus locus = Locus.lookup(tokens[i]);
+			if (locus == null) {
+				throw new IllegalArgumentException("Could not recognize locus token \"" + tokens[i]
+						+ "\" in file name \"" + file.getName() + "\" -- expected \"~\"-joined locus names "
+						+ "matching the order of columns in the file (e.g. \"A~C~B.xlsx\"), the same "
+						+ "convention this project's own bundled frequencies/nmdp/*.xlsx files use.");
+			}
+			positions[i] = locus;
+		}
+		return positions;
+	}
 
     /**
      * Main.
@@ -139,7 +166,11 @@ public class NormalizeFrequencyFile implements Callable<Integer> {
         Switch about = new Switch("a", "about", "display about message");
         Switch help  = new Switch("h", "help", "display help message");
         FileArgument inputFile = new FileArgument("i", "input-file", "input file, default stdin", false);
-        StringArgument frequencies = new StringArgument("f", "frequencies", "frequencies (acb, cb, drb1_dqb1, drb_dqb, five_loc, six_loc, single), default five_loc", false);
+        StringArgument frequencies = new StringArgument("f", "frequencies",
+                "\"single\" for an individual-locus frequency file; any other value (or omitted) for a "
+                        + "multi-locus haplotype file, whose column order is derived from the input file's own "
+                        + "\"~\"-joined name (e.g. A~C~B.xlsx), not from this argument",
+                false);
         FileArgument outputFile   = new FileArgument("o", "output-file", "output allele assignment file, default stdout", false);
 
         ArgumentList arguments  = new ArgumentList(about, help, inputFile, frequencies, outputFile);

--- a/ld-validation/src/main/java/org/dash/valid/freq/HLAFrequenciesLoader.java
+++ b/ld-validation/src/main/java/org/dash/valid/freq/HLAFrequenciesLoader.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.poifs.filesystem.FileMagic;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -476,33 +477,95 @@ public class HLAFrequenciesLoader {
 			Locus[] locusPositions) throws IOException, InvalidFormatException {
 		List<DisequilibriumElement> disequilibriumElements = new ArrayList<DisequilibriumElement>();
 
-		Workbook workbook = WorkbookFactory.create(inStream);
-       
-        // Return first sheet from the XLSX workbook
-        Sheet mySheet = workbook.getSheetAt(0);
-       
-        // Get iterator to all the rows in current sheet
-        Iterator<Row> rowIterator = mySheet.iterator();
-        
-        int firstRow = mySheet.getFirstRowNum();
-        
-        List<String> raceHeaders = null;
+		// The entire bundled 2007 NMDP reference dataset (frequencies/nmdp-2007/*.xls) is the
+		// legacy OLE2/BIFF binary format, not the ZIP-based OOXML format ".xlsx" implies --
+		// WorkbookFactory.create() always auto-detected and handled both transparently, but
+		// StreamingXlsxRows (see its class comment) only understands OOXML. Peeking the actual
+		// container format (not trusting the extension) means only genuinely OOXML input takes
+		// the streaming path; the OLE2 files, which were never the memory/performance problem
+		// StreamingXlsxRows exists to fix, keep going through the DOM reader that already
+		// handles them correctly.
+		InputStream markableStream = FileMagic.prepareToCheckMagic(inStream);
+		FileMagic magic = FileMagic.valueOf(markableStream);
 
-        // Traversing over each row of XLSX file
-        while (rowIterator.hasNext()) {
-            Row row = rowIterator.next();
+		if (FileMagic.OOXML.equals(magic)) {
+			ReferenceDataRowHandler rowHandler = new ReferenceDataRowHandler(disequilibriumElements, locusPositions);
+			StreamingXlsxRows.read(markableStream, rowHandler);
 
-            if (row.getRowNum() == firstRow) {
-            	raceHeaders = readHeaderElementsByRace(row);
-            }
-            else {
-	            disequilibriumElements.add(readDiseqilibriumElementsByRace(row, raceHeaders, locusPositions));
-            }            
-        }
-        
-        workbook.close();
-        
+			if (rowHandler.isCombinedHaplotypeFormat()) {
+				rankCombinedHaplotypeFrequencies(disequilibriumElements);
+			}
+		}
+		else {
+			loadNMDPLinkageReferenceDataDom(markableStream, locusPositions, disequilibriumElements);
+		}
+
         return disequilibriumElements;
+	}
+
+	// DOM (WorkbookFactory/Row/Cell) fallback for legacy OLE2 (.xls) reference files -- see
+	// loadNMDPLinkageReferenceData(InputStream, Locus[]) above for why this still exists
+	// alongside the SAX streaming path. The combined-haplotype layout (see
+	// COMBINED_HAPLOTYPE_HEADER) is only ever used by the 2026 nine-locus release, which is
+	// always OOXML, so this fallback only ever needs the original per-locus-column layout.
+	private static void loadNMDPLinkageReferenceDataDom(InputStream inStream, Locus[] locusPositions,
+			List<DisequilibriumElement> disequilibriumElements) throws IOException, InvalidFormatException {
+		Workbook workbook = WorkbookFactory.create(inStream);
+
+		Sheet mySheet = workbook.getSheetAt(0);
+		Iterator<Row> rowIterator = mySheet.iterator();
+		int firstRow = mySheet.getFirstRowNum();
+
+		List<String> raceHeaders = null;
+
+		while (rowIterator.hasNext()) {
+			Row row = rowIterator.next();
+
+			if (row.getRowNum() == firstRow) {
+				raceHeaders = readHeaderElementsByRaceDom(row);
+			}
+			else {
+				disequilibriumElements.add(readDiseqilibriumElementsByRaceDom(row, raceHeaders, locusPositions));
+			}
+		}
+
+		workbook.close();
+	}
+
+	// Row-by-row callback for loadNMDPLinkageReferenceData(InputStream, Locus[]) above: the
+	// first row streamed is always the header row (self-describing -- see
+	// COMBINED_HAPLOTYPE_HEADER), every row after that is a data row.
+	private static final class ReferenceDataRowHandler implements StreamingXlsxRows.RowHandler {
+		private final List<DisequilibriumElement> disequilibriumElements;
+		private final Locus[] locusPositions;
+		private boolean firstRowSeen;
+		private boolean combinedHaplotypeFormat;
+		private List<String> raceHeaders;
+
+		ReferenceDataRowHandler(List<DisequilibriumElement> disequilibriumElements, Locus[] locusPositions) {
+			this.disequilibriumElements = disequilibriumElements;
+			this.locusPositions = locusPositions;
+		}
+
+		@Override
+		public void row(int rowNum, List<String> row) {
+			if (!firstRowSeen) {
+				firstRowSeen = true;
+				combinedHaplotypeFormat = !row.isEmpty() && COMBINED_HAPLOTYPE_HEADER.equalsIgnoreCase(row.get(0));
+				raceHeaders = combinedHaplotypeFormat
+						? readCombinedHaplotypeHeaderElementsByRace(row)
+						: readHeaderElementsByRace(row);
+			}
+			else {
+				disequilibriumElements.add(combinedHaplotypeFormat
+						? readCombinedHaplotypeElementsByRace(row, raceHeaders, locusPositions)
+						: readDiseqilibriumElementsByRace(row, raceHeaders, locusPositions));
+			}
+		}
+
+		boolean isCombinedHaplotypeFormat() {
+			return combinedHaplotypeFormat;
+		}
 	}
 	
 	private void loadIndividualLocusFrequencies(File allelesFile) throws IOException {
@@ -568,23 +631,76 @@ public class HLAFrequenciesLoader {
 
 	public static List<String> loadIndividualLocusFrequency(InputStream inputStream)
 			throws IOException, InvalidFormatException {
+		// See loadNMDPLinkageReferenceData(InputStream, Locus[]) for why format is detected
+		// from the actual container bytes rather than assumed: the bundled 2007 NMDP
+		// single-locus files (frequencies/nmdp-2007/*.xls) are legacy OLE2, not OOXML, and
+		// StreamingXlsxRows only understands OOXML.
+		InputStream markableStream = FileMagic.prepareToCheckMagic(inputStream);
+		FileMagic magic = FileMagic.valueOf(markableStream);
+
+		if (FileMagic.OOXML.equals(magic)) {
+			return loadIndividualLocusFrequencyStreaming(markableStream);
+		}
+
+		return loadIndividualLocusFrequencyDom(markableStream);
+	}
+
+	private static List<String> loadIndividualLocusFrequencyStreaming(InputStream inputStream)
+			throws IOException, InvalidFormatException {
+		final List<String> singleLocusFrequencies = new ArrayList<String>();
+
+		// Streams rows via StreamingXlsxRows (SAX) rather than building the full in-memory
+		// DOM WorkbookFactory.create()/XSSFWorkbook would -- see loadNMDPLinkageReferenceData
+		// and StreamingXlsxRows' class comment for why.
+		StreamingXlsxRows.read(inputStream, new StreamingXlsxRows.RowHandler() {
+			private boolean firstRowSeen;
+			private String detectedLocus;
+			private String locusShortName;
+
+			@Override
+			public void row(int rowNum, List<String> row) {
+				if (!firstRowSeen) {
+					firstRowSeen = true;
+					// Legacy single-locus files header their first column with the locus
+					// name itself (e.g. "A"); the newer combined-haplotype layout (see
+					// loadNMDPLinkageReferenceData) headers it "Haplotype" instead, since
+					// every row's first cell already carries a fully-qualified allele string
+					// (e.g. "A*02:01") needing no locus name applied to it. Resolving the
+					// locus's short name only lazily, when a legacy-format data row actually
+					// needs it below, means a "Haplotype" header (which Locus.lookup()
+					// wouldn't recognize) no longer needs to resolve to anything up front.
+					detectedLocus = row.get(0);
+					return;
+				}
+
+				String cellValue = row.get(0);
+				if (!cellValue.contains(GLStringConstants.ASTERISK)) {
+					if (locusShortName == null) {
+						locusShortName = Locus.lookup(detectedLocus).getShortName();
+					}
+					cellValue = locusShortName + GLStringConstants.ASTERISK + cellValue.substring(0, 2) + GLStringUtilities.COLON + cellValue.substring(2);
+				}
+				singleLocusFrequencies.add(GLStringConstants.HLA_DASH + cellValue);
+			}
+		});
+
+		return singleLocusFrequencies;
+	}
+
+	// DOM (WorkbookFactory/Row/Cell) fallback for legacy OLE2 (.xls) single-locus reference
+	// files -- see loadIndividualLocusFrequency(InputStream) above.
+	private static List<String> loadIndividualLocusFrequencyDom(InputStream inputStream)
+			throws IOException, InvalidFormatException {
 		String detectedLocus = null;
 		String locusShortName = null;
 		List<String> singleLocusFrequencies = new ArrayList<String>();
 
 		Workbook workbook = WorkbookFactory.create(inputStream);
-		
-		// Return first sheet from the XLSX workbook
+
 		Sheet mySheet = workbook.getSheetAt(0);
-      
-		// Get iterator to all the rows in current sheet
 		Iterator<Row> rowIterator = mySheet.iterator();
-		
 		int firstRow = mySheet.getFirstRowNum();
-			
-		String cellValue = null;
-		
-		// Traversing over each row of XLSX file
+
 		while (rowIterator.hasNext()) {
 		    Row row = rowIterator.next();
 
@@ -593,52 +709,51 @@ public class HLAFrequenciesLoader {
 		    	locusShortName = Locus.lookup(detectedLocus).getShortName();
 		    	continue;
 		    }
-		    else {
-			    cellValue = row.getCell(0).getStringCellValue();
-			    if (!cellValue.contains(GLStringConstants.ASTERISK)) {
-			    	cellValue = locusShortName + GLStringConstants.ASTERISK + cellValue.substring(0, 2) + GLStringUtilities.COLON + cellValue.substring(2);
-			    }
-				singleLocusFrequencies.add(GLStringConstants.HLA_DASH + cellValue);
-		    }            
+
+		    String cellValue = row.getCell(0).getStringCellValue();
+		    if (!cellValue.contains(GLStringConstants.ASTERISK)) {
+		    	cellValue = locusShortName + GLStringConstants.ASTERISK + cellValue.substring(0, 2) + GLStringUtilities.COLON + cellValue.substring(2);
+		    }
+			singleLocusFrequencies.add(GLStringConstants.HLA_DASH + cellValue);
 		}
-		
+
 		workbook.close();
 		return singleLocusFrequencies;
 	}
 	
-	private static List<String> readHeaderElementsByRace(Row row) {		
+	// DOM (Row/Cell) counterpart of readHeaderElementsByRace(List<String>) below, used only by
+	// the legacy OLE2 (.xls) fallback path (see loadNMDPLinkageReferenceDataDom()).
+	private static List<String> readHeaderElementsByRaceDom(Row row) {
 		List<String> raceHeaders = new ArrayList<String>();
-		
+
 		Iterator<Cell> cellIterator = row.cellIterator();
 
 		while (cellIterator.hasNext()) {
 			Cell cell = cellIterator.next();
-			
+
 			String[] race = cell.getStringCellValue().split(UNDERSCORE);
 			raceHeaders.add(cell.getColumnIndex(), race[0]);
 		}
-		
+
 		return raceHeaders;
 	}
 
-	/**
-	 * @param row
-	 */
-	private static DisequilibriumElement readDiseqilibriumElementsByRace(Row row, List<String> raceHeaders, Locus[] locusPositions) {		
-		// For each row, iterate through each columns
+	// DOM (Row/Cell) counterpart of readDiseqilibriumElementsByRace(List<String>, ...) below,
+	// used only by the legacy OLE2 (.xls) fallback path.
+	private static DisequilibriumElement readDiseqilibriumElementsByRaceDom(Row row, List<String> raceHeaders, Locus[] locusPositions) {
 		Iterator<Cell> cellIterator = row.cellIterator();
-		
+
 		List<FrequencyByRace> frequenciesByRace  = new ArrayList<FrequencyByRace>();
 		DisequilibriumElementByRace disElement = new DisequilibriumElementByRace();
-		
+
 		int columnIndex;
 		String cellValue = null;
-		
+
 		while (cellIterator.hasNext()) {
 		    Cell cell = cellIterator.next();
 
 		    columnIndex = cell.getColumnIndex();
-		    
+
 		    if (columnIndex < locusPositions.length) {
 			    cellValue = cell.getStringCellValue();
 			    if (!cellValue.contains(GLStringConstants.ASTERISK)) {
@@ -650,34 +765,192 @@ public class HLAFrequenciesLoader {
 		    }
 		    else {
 		    	if ((locusPositions.length % 2 == 0 && columnIndex % 2 == 0) || (locusPositions.length % 2 != 0 && columnIndex % 2 != 0)) {
-		    		disElement.setFrequenciesByRace(loadFrequencyAndRank(row, cell, frequenciesByRace, raceHeaders));
+		    		disElement.setFrequenciesByRace(loadFrequencyAndRankDom(row, cell, frequenciesByRace, raceHeaders));
 		    	}
 		    }
 		}
-		
+
+	    return disElement;
+	}
+
+	// DOM (Row/Cell) counterpart of loadFrequencyAndRank(List<String>, ...) below, used only by
+	// the legacy OLE2 (.xls) fallback path.
+	private static List<FrequencyByRace> loadFrequencyAndRankDom(Row row, Cell cell,
+			List<FrequencyByRace> frequenciesByRace, List<String> raceHeaders) {
+		Double freq = cell.getNumericCellValue();
+
+		if (freq != 0) {
+			FrequencyByRace frequencyByRace = new FrequencyByRace(freq, ((Double) row.getCell(cell.getColumnIndex() + 1).getNumericCellValue()).toString(), raceHeaders.get(cell.getColumnIndex()));
+			frequenciesByRace.add(frequencyByRace);
+		}
+
+		Collections.sort(frequenciesByRace, new FrequencyByRaceComparator());
+
+		return frequenciesByRace;
+	}
+
+	private static List<String> readHeaderElementsByRace(List<String> row) {
+		List<String> raceHeaders = new ArrayList<String>();
+
+		for (String cellValue : row) {
+			String[] race = cellValue.split(UNDERSCORE);
+			raceHeaders.add(race[0]);
+		}
+
+		return raceHeaders;
+	}
+
+	/**
+	 * @param row
+	 */
+	private static DisequilibriumElement readDiseqilibriumElementsByRace(List<String> row, List<String> raceHeaders, Locus[] locusPositions) {
+		List<FrequencyByRace> frequenciesByRace  = new ArrayList<FrequencyByRace>();
+		DisequilibriumElementByRace disElement = new DisequilibriumElementByRace();
+
+		for (int columnIndex = 0; columnIndex < row.size(); columnIndex++) {
+		    if (columnIndex < locusPositions.length) {
+			    String cellValue = row.get(columnIndex);
+			    if (!cellValue.contains(GLStringConstants.ASTERISK)) {
+			    	cellValue = locusPositions[columnIndex].getShortName() + GLStringConstants.ASTERISK + cellValue.substring(0, 2) + GLStringUtilities.COLON + cellValue.substring(2);
+			    }
+			    List<String> val = new ArrayList<String>();
+			    val.add(GLStringConstants.HLA_DASH + cellValue);
+		    	disElement.setHlaElement(locusPositions[columnIndex], val);
+		    }
+		    else {
+		    	if ((locusPositions.length % 2 == 0 && columnIndex % 2 == 0) || (locusPositions.length % 2 != 0 && columnIndex % 2 != 0)) {
+		    		disElement.setFrequenciesByRace(loadFrequencyAndRank(row, columnIndex, frequenciesByRace, raceHeaders));
+		    	}
+		    }
+		}
+
 	    return disElement;
 	}
 
 	/**
 	 * @param row
+	 * @param columnIndex
 	 * @param frequenciesByRace
-	 * @param cell
-	 * @param idx
+	 * @param raceHeaders
 	 */
-	private static List<FrequencyByRace> loadFrequencyAndRank(Row row, Cell cell, 
+	private static List<FrequencyByRace> loadFrequencyAndRank(List<String> row, int columnIndex,
 			List<FrequencyByRace> frequenciesByRace, List<String> raceHeaders) {
-		Double freq = cell.getNumericCellValue();
-		
-		if (freq != 0) {
-			FrequencyByRace frequencyByRace = new FrequencyByRace(freq, ((Double) row.getCell(cell.getColumnIndex() + 1).getNumericCellValue()).toString(), raceHeaders.get(cell.getColumnIndex()));
-			frequenciesByRace.add(frequencyByRace);
+		// A frequency cell (and its companion rank cell) can legitimately be absent from the
+		// source XML entirely rather than present with a "0" value -- treat a blank the same
+		// as a zero frequency (skip it) instead of failing to parse it as a number.
+		String freqText = row.get(columnIndex);
+		if (!freqText.isEmpty()) {
+			double freq = Double.parseDouble(freqText);
+
+			if (freq != 0) {
+				String rankText = columnIndex + 1 < row.size() ? row.get(columnIndex + 1) : "";
+				// Matches the legacy DOM code's own transformation exactly: it read the rank
+				// cell's raw numeric value and re-stringified it via Double.toString() (e.g.
+				// "4" in the file becomes "4.0"), rather than passing the file's own text
+				// through unchanged.
+				String rank = rankText.isEmpty() ? null : Double.toString(Double.parseDouble(rankText));
+				frequenciesByRace.add(new FrequencyByRace(freq, rank, raceHeaders.get(columnIndex)));
+			}
 		}
-		
+
 		Collections.sort(frequenciesByRace, new FrequencyByRaceComparator());
-		
+
 		return frequenciesByRace;
 	}
-	
+
+	// Header row label that identifies the combined-haplotype layout (see
+	// loadNMDPLinkageReferenceData(InputStream, Locus[])).
+	private static final String COMBINED_HAPLOTYPE_HEADER = "Haplotype";
+
+	// Combined-haplotype layout's header row is: "Haplotype", one column per population
+	// (its plain name, e.g. "AAFA" -- no "_..." suffix to strip, unlike the legacy layout's
+	// readHeaderElementsByRace()), then "TotalFreq". Race headers are kept aligned to their
+	// column index (indices 0 and lastColumn left null and never read) so the shared
+	// raceHeaders.get(columnIndex) lookup pattern used elsewhere still works unchanged.
+	private static List<String> readCombinedHaplotypeHeaderElementsByRace(List<String> row) {
+		int lastColumn = row.size() - 1;
+		List<String> raceHeaders = new ArrayList<String>(Collections.nCopies(lastColumn + 1, (String) null));
+
+		for (int col = 1; col < lastColumn; col++) {
+			raceHeaders.set(col, row.get(col));
+		}
+
+		return raceHeaders;
+	}
+
+	// Parses one data row of the combined-haplotype layout. Column 0 is a single "~"-joined,
+	// already-fully-formatted haplotype string (e.g. "A*01:01~C*07:01~B*08:01"), so each
+	// locus's allele is read directly out of that one cell instead of from its own column,
+	// unlike readDiseqilibriumElementsByRace()'s per-locus columns. The remaining columns
+	// (excluding the trailing TotalFreq column) are plain per-population frequency values
+	// with no companion rank column -- rank isn't in this layout's source data at all, so it's
+	// left null here and filled in afterward by rankCombinedHaplotypeFrequencies(), once every
+	// row's frequency for a given population is known.
+	private static DisequilibriumElementByRace readCombinedHaplotypeElementsByRace(List<String> row, List<String> raceHeaders, Locus[] locusPositions) {
+		DisequilibriumElementByRace disElement = new DisequilibriumElementByRace();
+
+		String haplotype = row.get(0);
+		String[] tokens = haplotype.split(GLStringConstants.GENE_PHASE_DELIMITER);
+
+		for (int i = 0; i < tokens.length && i < locusPositions.length; i++) {
+			List<String> val = new ArrayList<String>();
+			val.add(GLStringConstants.HLA_DASH + tokens[i]);
+			disElement.setHlaElement(locusPositions[i], val);
+		}
+
+		List<FrequencyByRace> frequenciesByRace = new ArrayList<FrequencyByRace>();
+		int lastColumn = row.size() - 1;
+
+		for (int col = 1; col < lastColumn; col++) {
+			String freqText = row.get(col);
+			if (freqText.isEmpty()) {
+				continue;
+			}
+
+			double freq = Double.parseDouble(freqText);
+			if (freq != 0) {
+				frequenciesByRace.add(new FrequencyByRace(freq, null, raceHeaders.get(col)));
+			}
+		}
+
+		disElement.setFrequenciesByRace(frequenciesByRace);
+
+		return disElement;
+	}
+
+	// Computes rank for the combined-haplotype layout, which supplies no rank column (see
+	// readCombinedHaplotypeElementsByRace() above): for each population, every haplotype's
+	// FrequencyByRace entry for that population is ranked 1 (highest frequency) through N,
+	// matching what "rank" meant when it was read directly from the legacy layout's rank
+	// columns instead of computed.
+	private static void rankCombinedHaplotypeFrequencies(List<DisequilibriumElement> disequilibriumElements) {
+		HashMap<String, List<FrequencyByRace>> frequenciesByPopulation = new HashMap<String, List<FrequencyByRace>>();
+
+		for (DisequilibriumElement element : disequilibriumElements) {
+			for (FrequencyByRace frequencyByRace : ((DisequilibriumElementByRace) element).getFrequenciesByRace()) {
+				List<FrequencyByRace> forPopulation = frequenciesByPopulation.get(frequencyByRace.getRace());
+				if (forPopulation == null) {
+					forPopulation = new ArrayList<FrequencyByRace>();
+					frequenciesByPopulation.put(frequencyByRace.getRace(), forPopulation);
+				}
+				forPopulation.add(frequencyByRace);
+			}
+		}
+
+		for (List<FrequencyByRace> forPopulation : frequenciesByPopulation.values()) {
+			Collections.sort(forPopulation, new java.util.Comparator<FrequencyByRace>() {
+				@Override
+				public int compare(FrequencyByRace a, FrequencyByRace b) {
+					return Double.compare(b.getFrequency(), a.getFrequency());
+				}
+			});
+
+			for (int i = 0; i < forPopulation.size(); i++) {
+				forPopulation.get(i).setRank(String.valueOf(i + 1));
+			}
+		}
+	}
+
 	public List<DisequilibriumElement> loadLinkageReferenceData(String filename, Locus[] locusPositions) throws FileNotFoundException, IOException {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(HLAFrequenciesLoader.class.getClassLoader().getResourceAsStream(filename)));
 		String row;

--- a/ld-validation/src/main/java/org/dash/valid/freq/StreamingXlsxRows.java
+++ b/ld-validation/src/main/java/org/dash/valid/freq/StreamingXlsxRows.java
@@ -1,0 +1,190 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.freq;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.xssf.eventusermodel.XSSFReader;
+import org.apache.poi.xssf.model.SharedStrings;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Streams the first sheet of an XLSX file row by row via POI's low-level SAX (event) API,
+ * instead of the full in-memory DOM that WorkbookFactory.create()/XSSFWorkbook build. That DOM
+ * needs on the order of 10x a file's uncompressed XML size in heap, which made the larger NMDP
+ * nine-locus reference files (some ~150-170MB compressed) impractical to read at all: even a
+ * mid-sized 57MB file passed 2GB RSS and ran 15+ minutes without finishing the parse, still
+ * short of processing a single row.
+ *
+ * Each row is delivered as a plain List&lt;String&gt; of cell text in column order
+ * (blank/missing cells as empty strings, sized to that row's own last populated column),
+ * pre-resolved exactly the way POI's own Cell would resolve it for that XML cell type --
+ * numeric cells (t absent, or t="n") as the raw &lt;v&gt; text (the same text
+ * Cell.getNumericCellValue() itself parses as a double, so callers get identical precision,
+ * not a display-formatted approximation), "s" cells resolved via the shared strings table,
+ * "str"/"inlineStr" cells as their literal text, and other types passed through as-is -- so
+ * callers can keep working in terms of column index the same way they did against POI's
+ * Row/Cell, just calling Double.parseDouble() themselves where they'd previously called
+ * getNumericCellValue().
+ */
+class StreamingXlsxRows {
+
+	interface RowHandler {
+		void row(int rowNum, List<String> cellValues);
+	}
+
+	static void read(InputStream inStream, RowHandler handler) throws IOException {
+		try {
+			OPCPackage pkg = OPCPackage.open(inStream);
+			try {
+				XSSFReader reader = new XSSFReader(pkg);
+
+				SharedStrings sharedStrings;
+				try {
+					sharedStrings = reader.getSharedStringsTable();
+				}
+				catch (Exception e) {
+					// Not every workbook has a sharedStrings.xml part -- the NMDP nine-locus
+					// release's files don't (they use inline strings exclusively). Absence
+					// isn't an error here, it just means no "s"-typed cell will ever turn up
+					// below for a file that lacks one.
+					sharedStrings = null;
+				}
+
+				SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+				parserFactory.setNamespaceAware(true);
+				SAXParser saxParser = parserFactory.newSAXParser();
+
+				Iterator<InputStream> sheets = reader.getSheetsData();
+				if (sheets.hasNext()) {
+					InputStream sheetStream = sheets.next();
+					try {
+						saxParser.parse(sheetStream, new RowContentHandler(sharedStrings, handler));
+					}
+					finally {
+						sheetStream.close();
+					}
+				}
+			}
+			finally {
+				pkg.close();
+			}
+		}
+		catch (OpenXML4JException | SAXException | ParserConfigurationException e) {
+			throw new IOException("Failed to stream XLSX rows", e);
+		}
+	}
+
+	private static class RowContentHandler extends DefaultHandler {
+		private final SharedStrings sharedStrings;
+		private final RowHandler handler;
+
+		private List<String> currentRow;
+		private int currentRowNum;
+
+		private boolean inCell;
+		private boolean inValue;
+		private String cellType;
+		private int cellColumn;
+		private final StringBuilder valueBuffer = new StringBuilder();
+
+		RowContentHandler(SharedStrings sharedStrings, RowHandler handler) {
+			this.sharedStrings = sharedStrings;
+			this.handler = handler;
+		}
+
+		@Override
+		public void startElement(String uri, String localName, String qName, Attributes attributes) {
+			if ("row".equals(localName)) {
+				currentRow = new ArrayList<String>();
+				String rowAttr = attributes.getValue("r");
+				currentRowNum = rowAttr != null ? Integer.parseInt(rowAttr) : currentRowNum + 1;
+			}
+			else if ("c".equals(localName)) {
+				inCell = true;
+				cellType = attributes.getValue("t");
+				String cellRef = attributes.getValue("r");
+				cellColumn = cellRef != null ? new CellReference(cellRef).getCol() : currentRow.size();
+				valueBuffer.setLength(0);
+			}
+			else if (inCell && ("v".equals(localName) || "t".equals(localName))) {
+				// A cell holds either exactly one <v> (numeric/shared-string/boolean/error)
+				// or one or more <t> runs nested in <is> (inline rich text, possibly split
+				// across multiple runs); either way, accumulating into one per-cell buffer
+				// and committing it once at </c> handles both correctly.
+				inValue = true;
+			}
+		}
+
+		@Override
+		public void characters(char[] ch, int start, int length) {
+			if (inValue) {
+				valueBuffer.append(ch, start, length);
+			}
+		}
+
+		@Override
+		public void endElement(String uri, String localName, String qName) {
+			if ("v".equals(localName) || "t".equals(localName)) {
+				inValue = false;
+			}
+			else if ("c".equals(localName)) {
+				inCell = false;
+				commitCellValue();
+			}
+			else if ("row".equals(localName)) {
+				handler.row(currentRowNum, currentRow);
+				currentRow = null;
+			}
+		}
+
+		private void commitCellValue() {
+			String text = valueBuffer.toString();
+
+			if ("s".equals(cellType) && sharedStrings != null) {
+				int idx = Integer.parseInt(text);
+				RichTextString richText = sharedStrings.getItemAt(idx);
+				text = richText == null ? "" : richText.getString();
+			}
+
+			while (currentRow.size() <= cellColumn) {
+				currentRow.add("");
+			}
+			currentRow.set(cellColumn, text);
+		}
+	}
+}

--- a/ld-validation/src/test/java/org/dash/valid/HLAFrequenciesLoaderCombinedFormatTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/HLAFrequenciesLoaderCombinedFormatTest.java
@@ -1,0 +1,222 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.dash.valid.freq.HLAFrequenciesLoader;
+import org.dash.valid.race.DisequilibriumElementByRace;
+import org.dash.valid.race.FrequencyByRace;
+import org.junit.jupiter.api.Test;
+
+// Regression tests for the two reference-file layouts HLAFrequenciesLoader.
+// loadNMDPLinkageReferenceData(InputStream, Locus[]) and loadIndividualLocusFrequency(InputStream)
+// now read via StreamingXlsxRows (SAX) rather than the DOM WorkbookFactory.create()/XSSFWorkbook
+// previously used. That switch was needed because the DOM approach couldn't practically read the
+// NMDP nine-locus reference release's larger files (up to ~170MB compressed): even a mid-sized
+// 57MB file ran 15+ minutes and past 2GB RSS without finishing the parse. Existing coverage
+// (HLAFrequenciesLoaderTest.testLoadNMDPLinkageReferenceData) already exercises the streaming
+// reader against a real bundled legacy-layout file; these tests instead build small workbooks in
+// memory via POI so both layouts' parsing logic -- including the new-format rank computation and
+// zero/blank-frequency handling neither had a direct test for before -- are pinned down with known
+// expected values, without needing to check a large, non-redistributable fixture into the repo.
+public class HLAFrequenciesLoaderCombinedFormatTest {
+
+	private static InputStream workbookToStream(XSSFWorkbook workbook) throws Exception {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		workbook.write(out);
+		workbook.close();
+		return new ByteArrayInputStream(out.toByteArray());
+	}
+
+	private static void setCell(Row row, int col, String value) {
+		row.createCell(col).setCellValue(value);
+	}
+
+	private static void setCell(Row row, int col, double value) {
+		row.createCell(col).setCellValue(value);
+	}
+
+	// Builds a combined-haplotype-layout workbook (see HLAFrequenciesLoader's
+	// COMBINED_HAPLOTYPE_HEADER): one "Haplotype" column, one frequency column per named
+	// population, then "TotalFreq". A null frequency leaves that cell entirely absent from the
+	// row, matching how the real NMDP nine-locus release's files omit zero-frequency cells
+	// rather than writing literal 0s.
+	private static InputStream buildCombinedHaplotypeWorkbook(String[] populations, String[] haplotypes, Double[][] frequencies) throws Exception {
+		XSSFWorkbook workbook = new XSSFWorkbook();
+		Sheet sheet = workbook.createSheet("Sheet1");
+
+		Row header = sheet.createRow(0);
+		setCell(header, 0, "Haplotype");
+		for (int p = 0; p < populations.length; p++) {
+			setCell(header, p + 1, populations[p]);
+		}
+		setCell(header, populations.length + 1, "TotalFreq");
+
+		for (int h = 0; h < haplotypes.length; h++) {
+			Row row = sheet.createRow(h + 1);
+			setCell(row, 0, haplotypes[h]);
+			double total = 0;
+			for (int p = 0; p < populations.length; p++) {
+				Double freq = frequencies[h][p];
+				if (freq != null) {
+					setCell(row, p + 1, freq.doubleValue());
+					total += freq.doubleValue();
+				}
+			}
+			setCell(row, populations.length + 1, total);
+		}
+
+		return workbookToStream(workbook);
+	}
+
+	@Test
+	public void testCombinedHaplotypeFormatParsesLociAndFrequencies() throws Exception {
+		InputStream inStream = buildCombinedHaplotypeWorkbook(
+				new String[] { "AAFA", "CAU" },
+				new String[] {
+						"A*01:01~C*07:01~B*08:01",
+						"A*02:01~C*05:01~B*44:02"
+				},
+				new Double[][] {
+						{ 0.05, 0.02 },
+						{ 0.10, 0.09 }
+				});
+
+		List<DisequilibriumElement> elements = HLAFrequenciesLoader.loadNMDPLinkageReferenceData(
+				inStream, new Locus[] { Locus.HLA_A, Locus.HLA_C, Locus.HLA_B });
+
+		assertEquals(2, elements.size());
+
+		DisequilibriumElement first = elements.get(0);
+		assertTrue(first.getHlaElement(Locus.HLA_A).contains("HLA-A*01:01"));
+		assertTrue(first.getHlaElement(Locus.HLA_C).contains("HLA-C*07:01"));
+		assertTrue(first.getHlaElement(Locus.HLA_B).contains("HLA-B*08:01"));
+
+		DisequilibriumElement second = elements.get(1);
+		assertTrue(second.getHlaElement(Locus.HLA_A).contains("HLA-A*02:01"));
+	}
+
+	@Test
+	public void testCombinedHaplotypeFormatComputesRankPerPopulation() throws Exception {
+		// AAFA frequencies (desc): h2 (0.10) > h1 (0.05) > h3 (0.02) -> ranks 1, 2, 3
+		// CAU  frequencies (desc): h3 (0.20) > h2 (0.09) > h1 (0.02) -> ranks 1, 2, 3
+		InputStream inStream = buildCombinedHaplotypeWorkbook(
+				new String[] { "AAFA", "CAU" },
+				new String[] {
+						"A*01:01~C*07:01~B*08:01",
+						"A*02:01~C*05:01~B*44:02",
+						"A*03:01~C*07:02~B*07:02"
+				},
+				new Double[][] {
+						{ 0.05, 0.02 },
+						{ 0.10, 0.09 },
+						{ 0.02, 0.20 }
+				});
+
+		List<DisequilibriumElement> elements = HLAFrequenciesLoader.loadNMDPLinkageReferenceData(
+				inStream, new Locus[] { Locus.HLA_A, Locus.HLA_C, Locus.HLA_B });
+
+		assertEquals(3, elements.size());
+
+		assertRank(elements.get(0), "AAFA", "2");
+		assertRank(elements.get(1), "AAFA", "1");
+		assertRank(elements.get(2), "AAFA", "3");
+
+		assertRank(elements.get(0), "CAU", "3");
+		assertRank(elements.get(1), "CAU", "2");
+		assertRank(elements.get(2), "CAU", "1");
+	}
+
+	@Test
+	public void testCombinedHaplotypeFormatOmitsBlankFrequencyCells() throws Exception {
+		// h2 has no AAFA frequency at all (the cell is entirely absent from the row, not a
+		// literal 0) -- it must not appear in h2's frequenciesByRace for AAFA, while h1 and h3
+		// (which do have an AAFA frequency) still do.
+		InputStream inStream = buildCombinedHaplotypeWorkbook(
+				new String[] { "AAFA" },
+				new String[] {
+						"A*01:01~C*07:01~B*08:01",
+						"A*02:01~C*05:01~B*44:02",
+						"A*03:01~C*07:02~B*07:02"
+				},
+				new Double[][] {
+						{ 0.05 },
+						{ null },
+						{ 0.02 }
+				});
+
+		List<DisequilibriumElement> elements = HLAFrequenciesLoader.loadNMDPLinkageReferenceData(
+				inStream, new Locus[] { Locus.HLA_A, Locus.HLA_C, Locus.HLA_B });
+
+		assertTrue(hasFrequencyForRace(elements.get(0), "AAFA"));
+		assertTrue(!hasFrequencyForRace(elements.get(1), "AAFA"));
+		assertTrue(hasFrequencyForRace(elements.get(2), "AAFA"));
+
+		// The two haplotypes that do have an AAFA frequency are still ranked 1 and 2 between
+		// themselves; the blank row simply isn't part of that ranking at all.
+		assertRank(elements.get(0), "AAFA", "1");
+		assertRank(elements.get(2), "AAFA", "2");
+	}
+
+	@Test
+	public void testLoadIndividualLocusFrequencyCombinedFormat() throws Exception {
+		InputStream inStream = buildCombinedHaplotypeWorkbook(
+				new String[] { "AAFA" },
+				new String[] { "A*02:01", "A*24:02" },
+				new Double[][] { { 0.5 }, { 0.3 } });
+
+		List<String> alleles = HLAFrequenciesLoader.loadIndividualLocusFrequency(inStream);
+
+		assertEquals(2, alleles.size());
+		assertTrue(alleles.get(0).equals("HLA-A*02:01"));
+		assertTrue(alleles.get(1).equals("HLA-A*24:02"));
+	}
+
+	private static void assertRank(DisequilibriumElement element, String race, String expectedRank) {
+		for (FrequencyByRace frequencyByRace : ((DisequilibriumElementByRace) element).getFrequenciesByRace()) {
+			if (race.equals(frequencyByRace.getRace())) {
+				assertEquals(expectedRank, frequencyByRace.getRank());
+				return;
+			}
+		}
+		throw new AssertionError("No frequency found for race " + race);
+	}
+
+	private static boolean hasFrequencyForRace(DisequilibriumElement element, String race) {
+		for (FrequencyByRace frequencyByRace : ((DisequilibriumElementByRace) element).getFrequenciesByRace()) {
+			if (race.equals(frequencyByRace.getRace())) {
+				return true;
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

`NormalizeFrequencyFile` derived its locus column order from a hardcoded `Map<EnumSet<Locus>, Locus[]>`, so any new NMDP reference file combination (e.g. the 2026 nine-locus Zenodo release's DRBX/DQA1/DPA1/DPB1 files) needed new `Locus`/`Linkages` enum constants registered ahead of time. Column order is now derived from the input file's own `"~"`-joined name (the same convention this project's bundled `frequencies/nmdp/*.xlsx` files already use), so any combination `Locus.lookup()` recognizes works without code changes.

Verifying this against real files surfaced three unrelated, pre-existing problems, all fixed here:

1. **commons-compress version conflict** — `dsh-compress`'s transitive `commons-compress 1.21` was winning Maven's "nearest wins" resolution over `poi-ooxml`'s required `1.28.0`. Regression from this project's own Phase 1 POI bump (5.2.2 → 5.5.1); `poi-ooxml` 5.2.2 itself required exactly 1.21, so the two used to agree by coincidence. Declaring `commons-compress 1.28.0` directly overrides it.

2. **New file layout** — the 2026 release uses one combined `"Haplotype"` column (e.g. `"A*01:01~C*07:01~B*08:01"`) instead of one column per locus, and a plain frequency column per population with no rank column. Added a second parsing path in `HLAFrequenciesLoader`, detected from the file's own header row, computing rank per population from the frequency data itself where the source doesn't supply it.

3. **DOM parsing doesn't scale** — the larger files in the new release (up to ~180MB) can't practically be read via POI's DOM API: a 57MB file ran 15+ minutes and past 2GB RSS without finishing the parse. Added `StreamingXlsxRows`, a SAX-based reader, and switched the loader to use it — verified byte-identical output against the old DOM path on real files first. The bundled 2007 NMDP dataset turned out to be legacy OLE2 (`.xls`), which the streaming reader can't read; both affected methods now detect the actual container format via POI's `FileMagic` and fall back to the original DOM path for OLE2 input (never the performance problem in the first place).

## Testing

- Added `HLAFrequenciesLoaderCombinedFormatTest`: new-layout locus/frequency parsing, per-population rank computation, and blank (not just zero) frequency-cell handling — none had direct coverage before.
- Full `ld-validation` suite (46 tests) and the CI-equivalent `mvn -DskipTests clean package` + `mvn verify` pass.
- Verified end-to-end against all 25 file combinations in the actual 2026 NMDP nine-locus Zenodo release (~1.6GB of source XLSX, including two ~150-180MB files), converted to this project's standard CSV format without error. Those converted files stay local only — CC-BY-NC-ND licensed, not redistributable, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)