### PR TITLE
Upgrade to Java 25 LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     # Be sure to update the Docker image tag below to openjdk version of your application.
     # A list of available CircleCI Docker Convenience Images are available here: https://circleci.com/developer/images/image/cimg/openjdk
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:25.0
     resource_class: large
     # Add steps to the job
     # See: https://circleci.com/docs/2.0/configuration-reference/#steps

--- a/ld-validation/pom.xml
+++ b/ld-validation/pom.xml
@@ -141,7 +141,11 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <!-- 0.8.12 can't read Java 25's class file format (major version 69) at all;
+             "Unsupported class file major version 69" during report generation, even though
+             the tests themselves compile and run fine under 25. Java 25 support landed in
+             0.8.14; using the latest (0.8.15) rather than pinning to the minimum that works. -->
+        <version>0.8.15</version>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <module>ld-service</module>
   </modules>
   <properties>
-    <java.version>17</java.version>
+    <java.version>25</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.enforcer.jdk-version>[${java.version},]</maven.enforcer.jdk-version>


### PR DESCRIPTION
## Why now

Java 17's Oracle Premier Support ends **2026-09-30** — about 5 weeks away. This project runs Eclipse Temurin builds (`cimg/openjdk` in CI, Homebrew `openjdk@17` locally), not Oracle JDK, but Temurin's free LTS builds track the same upstream OpenJDK 17 update project Oracle leads, and are expected to stop getting free security patches on essentially the same timeline.

## Why 25, not 21

Both are viable LTS targets (21 → support to 2028, 25 → support to 2030), but the switching cost is identical either way: the whole reactor already isolates the Java version behind one `<java.version>` property. No reason to pick the shorter runway for the same effort.

## Changes

- `pom.xml`: `java.version` 17 → 25.
- `.circleci/config.yml`: `cimg/openjdk:17.0` → `25.0` (confirmed this tag exists and is actively maintained via the Docker Hub API directly, not assumed).
- `ld-validation/pom.xml`: `jacoco-maven-plugin` 0.8.12 → 0.8.15. 0.8.12 can't read Java 25's class file format at all ("Unsupported class file major version 69") during coverage-report generation, even though the tests themselves compile and run fine under 25. Java 25 support landed in 0.8.14; used the latest release (0.8.15).

## Verification

- Full reactor `mvn clean verify` passes (50 tests) under a real local JDK 25 (Homebrew `openjdk@25`), not just a version-number bump.
- Booted the packaged `ld-service` jar for real under Java 25 and confirmed it actually serves requests (200 on both `/swagger-ui/index.html` and `/v3/api-docs`) — same verification standard used for the Boot 3 migration (Phase 3c) rather than trusting `mvn test` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)