### PR TITLE
Remove dead validate-gl-ld/extract-mugs appassembler entries

### DIFF
--- a/ld-tools/pom.xml
+++ b/ld-tools/pom.xml
@@ -120,14 +120,16 @@
           <repositoryName>lib</repositoryName>
           <installBooterArtifacts>false</installBooterArtifacts>
           <programs>
-            <program>
-              <id>validate-gl-ld</id>
-              <mainClass>org.nmdp.validation.tools.ValidateLdGlstrings</mainClass>
-            </program>
-            <program>
-              <id>extract-mugs</id>
-              <mainClass>org.nmdp.validation.tools.ExtractMugs</mainClass>
-            </program>
+            <!-- validate-gl-ld (org.nmdp.validation.tools.ValidateLdGlstrings) and
+                 extract-mugs (org.nmdp.validation.tools.ExtractMugs) were removed here
+                 until 2026-08-25: both classes were deleted back in commit a6ca96b
+                 ("Enhanced CWD and CIWD reporting", 2021-02-14) as part of a refactor
+                 that consolidated their functionality elsewhere (that same commit
+                 touched HLALinkageDisequilibrium/GLStringUtilities/etc.), but this
+                 program list was never updated to match, so the built distribution
+                 kept shipping bin/validate-gl-ld and bin/extract-mugs scripts that
+                 would fail immediately with ClassNotFoundException if actually run,
+                 for over 5 years, never restored or needed since. -->
             <program>
             	<id>analyze-gl-strings</id>
             	<mainClass>org.nmdp.validation.tools.AnalyzeGLStrings</mainClass>


### PR DESCRIPTION
`ld-tools/pom.xml`'s appassembler config declared two CLI programs whose `mainClass` (`ValidateLdGlstrings`, `ExtractMugs`) doesn't exist anywhere in the repo.

Traced the history: both classes were deleted in commit `a6ca96b` ("Enhanced CWD and CIWD reporting", 2021-02-14), a refactor that touched `HLALinkageDisequilibrium`/`GLStringUtilities`/etc. (presumably consolidating their functionality into what's now `AnalyzeGLStrings`), but never updated this program list to match. The built distribution has been shipping `bin/validate-gl-ld` and `bin/extract-mugs` scripts that would fail immediately with `ClassNotFoundException` if actually run, for **over 5 years** — nothing in the test suite or README references either tool.

Verified: full reactor `mvn clean verify` passes (50 tests); the built distribution's `bin/` now only contains the three tools that actually work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)