### PR TITLE
Phase 6c: javadoc for the public API surface

### DIFF
--- a/ld-tools/src/main/java/org/nmdp/validation/tools/AnalyzeGLStrings.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/AnalyzeGLStrings.java
@@ -61,8 +61,11 @@ import org.dishevelled.commandline.argument.FileSetArgument;
 import org.dishevelled.commandline.argument.StringArgument;
 
 /**
- * AnalyzeGLStrings
- *
+ * CLI entry point for {@code analyze-gl-strings} — runs
+ * {@link org.dash.valid.LinkageDisequilibriumAnalyzer} against one or more GL String files
+ * and writes the full report set ({@code summary.xml}, {@code linkages.log},
+ * {@code haplotypePairs.log}, {@code detectedFindings.csv}, etc.) via the writer classes in
+ * {@link org.dash.valid.report}. See the root README for the full CLI argument reference.
  */
 public class AnalyzeGLStrings implements Callable<Integer> {
 	
@@ -77,10 +80,18 @@ public class AnalyzeGLStrings implements Callable<Integer> {
 
 
     /**
-     * Analyze gl string using linkage disequilibrium frequencies
+     * Builds the analysis job for one batch run.
      *
-     * @param inputFile input file, if any
-     * @param outputFile output interpretation file, if any
+     * @param inputFile GL String input file
+     * @param outputFile output directory for the report set
+     * @param hladb IMGT/HLA reference database version to validate against (see the root
+     *              README's {@code org.dash.hladb} property)
+     * @param freq frequency set to use (see the root README's {@code org.dash.frequencies}
+     *             property)
+     * @param warnings whether to also write the *Warnings.log files
+     * @param frequencyFiles custom frequency reference files, if any (standard format,
+     *                       e.g. from {@code normalize-frequency-file})
+     * @param allelesFile custom individual-locus allele frequency file, if any
      */
     public AnalyzeGLStrings(File inputFile, File outputFile, String hladb, String freq, Boolean warnings, Set<File> frequencyFiles, File allelesFile) {
         this.inputFile = inputFile;

--- a/ld-tools/src/main/java/org/nmdp/validation/tools/NormalizeFrequencyFile.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/NormalizeFrequencyFile.java
@@ -43,8 +43,12 @@ import org.dishevelled.commandline.argument.FileArgument;
 import org.dishevelled.commandline.argument.StringArgument;
 
 /**
- * AnalyzeGLStrings
- *
+ * CLI entry point for {@code normalize-frequency-file} — converts an NMDP haplotype
+ * frequency reference file into this project's own standard comma-delimited format, so it
+ * can be passed to {@code analyze-gl-strings} via {@code -q}. Handles both the legacy
+ * per-locus-column layout and the newer combined-haplotype layout (auto-detected from the
+ * file's own header row); multi-locus column order is derived from the input file's own
+ * {@code "~"}-joined name (e.g. {@code A~C~B.xlsx}).
  */
 public class NormalizeFrequencyFile implements Callable<Integer> {
 
@@ -58,10 +62,12 @@ public class NormalizeFrequencyFile implements Callable<Integer> {
 
 
     /**
-     * Normalize frequency files into a standardized format
+     * Builds the conversion job for one input file.
      *
-     * @param inputFile input file, if any
-     * @param outputFile output interpretation file, if any
+     * @param inputFile input frequency reference file
+     * @param frequencies {@link #SINGLE} for an individual-locus frequency file; any other
+     *                    value (or {@code null}) for a multi-locus haplotype file
+     * @param outputFile output file, in this project's standard format
      */
     public NormalizeFrequencyFile(File inputFile, String frequencies, File outputFile) {
         this.inputFile = inputFile;

--- a/ld-validation/src/main/java/org/dash/valid/CoreDisequilibriumElement.java
+++ b/ld-validation/src/main/java/org/dash/valid/CoreDisequilibriumElement.java
@@ -5,7 +5,20 @@ import java.util.List;
 
 import org.dash.valid.gl.haplo.Haplotype;
 
-public class CoreDisequilibriumElement extends DisequilibriumElement {	
+/**
+ * A minimal {@link DisequilibriumElement} used to represent a <em>candidate</em> haplotype
+ * being matched against reference data — not a reference row itself. Built directly from a
+ * candidate's alleles so {@link DisequilibriumElement#equals} can be used to search the
+ * reference list (see {@link org.dash.valid.HLALinkageDisequilibrium}) without needing a
+ * real frequency of its own.
+ */
+public class CoreDisequilibriumElement extends DisequilibriumElement {
+	/**
+	 * Builds a candidate element from one haplotype's own alleles.
+	 *
+	 * @param hlaElementMap this candidate's alleles, by locus
+	 * @param haplotype the haplotype this element represents
+	 */
 	public CoreDisequilibriumElement(HashMap<Locus, List<String>> hlaElementMap, Haplotype haplotype) {
 		setHlaElementMap(hlaElementMap);
 		setHaplotype(haplotype);

--- a/ld-validation/src/main/java/org/dash/valid/DisequilibriumElement.java
+++ b/ld-validation/src/main/java/org/dash/valid/DisequilibriumElement.java
@@ -31,7 +31,18 @@ import org.dash.valid.gl.GLStringUtilities;
 import org.dash.valid.gl.haplo.Haplotype;
 
 
-public abstract class DisequilibriumElement {	
+/**
+ * One reference row of haplotype frequency data — the alleles at each locus of a known
+ * haplotype, plus its frequency (see the {@link org.dash.valid.freq} loaders that build
+ * these, and the {@link org.dash.valid.race}/{@link org.dash.valid.base} subclasses that add
+ * per-race or single-frequency data).
+ * <p>
+ * {@link #equals(Object)} compares at the G-group/Antigen Recognition Site level (via
+ * {@link GLStringUtilities#fieldLevelComparison} / {@link GLStringUtilities#checkAntigenRecognitionSite}),
+ * not by exact allele string — so a candidate haplotype whose own recorded ambiguity spans
+ * several raw allele strings can still match a single reference row.
+ */
+public abstract class DisequilibriumElement {
 	private Haplotype haplotype;
 	public DisequilibriumElement() {
 		super();

--- a/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
+++ b/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
@@ -45,24 +45,29 @@ import org.dash.valid.gl.haplo.MultiLocusHaplotype;
 import org.dash.valid.report.DetectedDisequilibriumElement;
 import org.dash.valid.report.DetectedLinkageFindings;
 
-/*
- * Linkage disequilibrium
- * 
- * Non-random association of alleles at two or more loci that descend from a single,
- * ancestral chromosome
- * 
- * http://en.wikipedia.org/wiki/Linkage_disequilibrium
- * 
- * This class leverages a specific set of linkage disequilibrium associations relevant in the context
- * of HLA (http://en.wikipedia.org/wiki/Human_leukocyte_antigen) and immunogenetics.
- * 
+/**
+ * Detects <a href="http://en.wikipedia.org/wiki/Linkage_disequilibrium">linkage
+ * disequilibrium</a> (LD) — the non-random association of alleles at two or more loci that
+ * descend from a single, ancestral chromosome — for the specific set of HLA locus
+ * combinations this project tracks (see {@link Linkages}), by matching candidate
+ * haplotypes against reference haplotype frequency data (see
+ * {@link org.dash.valid.freq.HLAFrequenciesLoader}).
  */
-
 public class HLALinkageDisequilibrium {
 
     private static final Logger LOGGER = Logger.getLogger(HLALinkageDisequilibrium.class.getName());
-			
-	public static Sample hasLinkageDisequilibrium(LinkageDisequilibriumGenotypeList glString) {	
+
+	/**
+	 * Detects linkage disequilibrium for an unphased genotype, enumerating every haplotype
+	 * combination the genotype's own recorded ambiguity allows (via
+	 * {@link LinkageDisequilibriumGenotypeList#getPossibleHaplotypes(EnumSet)}) and matching
+	 * each against the reference frequency data for every tracked {@link Linkages} locus
+	 * combination.
+	 *
+	 * @param glString the parsed genotype to detect linkages for
+	 * @return a {@link Sample} wrapping the genotype and its {@link DetectedLinkageFindings}
+	 */
+	public static Sample hasLinkageDisequilibrium(LinkageDisequilibriumGenotypeList glString) {
 		Sample sample = new Sample(glString);
 		
 		Set<HaplotypePair> linkedPairs = new HaplotypePairSet(new HaplotypePairComparator());
@@ -97,7 +102,19 @@ public class HLALinkageDisequilibrium {
 		return sample;
 	}
 	
-	public static Sample hasLinkageDisequilibrium(LinkageDisequilibriumGenotypeList glString, List<Haplotype> knownHaplotypes) {		
+	/**
+	 * Detects linkage disequilibrium for a genotype whose haplotypes are already known
+	 * (e.g. already phased, via {@link org.dash.valid.gl.GLStringUtilities#buildHaplotypes}),
+	 * instead of enumerating candidates from ambiguity. Each known haplotype is matched
+	 * against reference data via {@link #enrichHaplotype}; a linkage is only reported for a
+	 * given locus combination when exactly two of the known haplotypes both matched
+	 * (a linked pair).
+	 *
+	 * @param glString the parsed genotype (used for CWD/CIWD checks and to build the result)
+	 * @param knownHaplotypes the genotype's already-known haplotypes
+	 * @return a {@link Sample} wrapping the genotype and its {@link DetectedLinkageFindings}
+	 */
+	public static Sample hasLinkageDisequilibrium(LinkageDisequilibriumGenotypeList glString, List<Haplotype> knownHaplotypes) {
 		Set<HaplotypePair> linkedPairs = new HaplotypePairSet(new HaplotypePairComparator());
 
 		Set<String> notCommon = GLStringUtilities.checkCommonWellDocumented(glString.getGLString());
@@ -144,6 +161,23 @@ public class HLALinkageDisequilibrium {
 		return sample;
 	}
 
+	/**
+	 * Matches one already-known haplotype against reference frequency data for a single
+	 * locus combination, returning a copy annotated with its {@link Haplotype#getLinkage()}
+	 * if a match was found (or with no linkage set, if not). Matching is by
+	 * {@link DisequilibriumElement#equals}, which compares at the G-group/ARS level rather
+	 * than exact allele strings, so a haplotype carrying its own locus-level allele
+	 * ambiguity can in principle match more than one distinct reference row; this method
+	 * does not (currently) apply any explicit tie-break for that case the way
+	 * {@link #hasLinkageDisequilibrium(LinkageDisequilibriumGenotypeList, List)}'s own
+	 * candidate-enumeration path does — see the class-internal notes on
+	 * {@code findLinkedPairs} for that mechanism.
+	 *
+	 * @param loci the locus combination to match against
+	 * @param disequilibriumElements reference data for that locus combination
+	 * @param haplotype the known haplotype to match
+	 * @return a copy of {@code haplotype}, annotated with a linkage if one was found
+	 */
 	public static Haplotype enrichHaplotype(EnumSet<Locus> loci, List<DisequilibriumElement> disequilibriumElements, Haplotype haplotype) {
 		MultiLocusHaplotype enrichedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(haplotype.getAlleleMap()), 
 				new HashMap<Locus, Integer>(haplotype.getHaplotypeInstanceMap()), haplotype.getDrb345Homozygous());

--- a/ld-validation/src/main/java/org/dash/valid/gl/haplo/Haplotype.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/haplo/Haplotype.java
@@ -34,12 +34,29 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 
+/**
+ * One haplotype — an ordered set of alleles across one or more loci believed to descend
+ * together from a single ancestral chromosome. {@link MultiLocusHaplotype} is the concrete
+ * implementation used throughout this project; see {@link HaplotypePair} for how two
+ * haplotypes combine into a detected linkage.
+ * <p>
+ * {@code equals()}/{@code hashCode()} are based solely on {@link #getHaplotypeString()}
+ * (the canonical, G-group-level representation) — deliberately, since a plain per-field
+ * comparison here was a real source of run-to-run non-determinism before that was fixed
+ * (see the inline comment on {@link #equals(Object)}).
+ */
 @XmlRootElement(name="haplotype")
 @XmlType(propOrder={"sequence", "haplotypeString"})
-public abstract class Haplotype {	
+public abstract class Haplotype {
 	DetectedDisequilibriumElement linkage;
 	private boolean drb345Homozygous;
-	
+
+	/**
+	 * The reference-data match found for this haplotype, if any.
+	 *
+	 * @return the reference-data linkage this haplotype matched, or {@code null} if no
+	 *         match was found (see {@link org.dash.valid.HLALinkageDisequilibrium})
+	 */
 	@XmlTransient
 	public DetectedDisequilibriumElement getLinkage() {
 		return linkage;
@@ -61,9 +78,23 @@ public abstract class Haplotype {
 	public abstract Integer getSequence();
 	public abstract void setSequence(Integer sequence);
 	
+	/**
+	 * The canonical representation used for matching, equality, and hashing.
+	 *
+	 * @return the canonical, G-group-level representation of this haplotype (e.g.
+	 *         {@code "HLA-C*07:01g~HLA-B*08:01g"}) — reported as {@code value} in output XML
+	 */
 	@XmlAttribute(name="value")
 	public abstract String getHaplotypeString();
-	
+
+	/**
+	 * The fully expanded representation, distinct from the canonical {@link #getHaplotypeString()}.
+	 *
+	 * @return the fully expanded, allele-level representation of this haplotype (e.g. every
+	 *         specific allele the matched G-group(s) resolved to) — reported as
+	 *         {@code fullValue} in output XML. Distinct from {@link #getHaplotypeString()}
+	 *         since reference-data matching is G-group/ARS-based, not exact-allele-string.
+	 */
 	@XmlAttribute(name="fullValue")
 	public abstract String getFullHaplotypeString();
 	

--- a/ld-validation/src/main/java/org/dash/valid/gl/haplo/HaplotypePair.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/haplo/HaplotypePair.java
@@ -39,6 +39,16 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 
+/**
+ * Two {@link Haplotype}s detected as a linked pair at one locus combination, plus their
+ * combined frequency. Reported as {@code <haplo-pair>} in output XML.
+ * <p>
+ * The two haplotypes' {@code seq="1"}/{@code seq="2"} ordering (and, by extension, which
+ * one appears first when reading a pair) is assigned deterministically by
+ * {@link HaplotypeComparator} in the constructor, not by construction order — see
+ * {@link #equals(Object)}, which treats either ordering as equal, and {@link #hashCode()},
+ * which is order-independent to match.
+ */
 @XmlRootElement(name="haplo-pair")
 @XmlType(propOrder={"haplotypes", "frequencies", "frequency"})
 public class HaplotypePair {
@@ -50,6 +60,13 @@ public class HaplotypePair {
 	
     private static final Logger LOGGER = Logger.getLogger(HaplotypePair.class.getName());
 	
+	/**
+	 * Convenience accessor for whichever frequency representation this pair actually has.
+	 *
+	 * @return the first per-race frequency in {@link #getFrequencies()} if this pair's
+	 *         reference data is race-stratified, otherwise the single overall
+	 *         {@link #getFrequency()} string
+	 */
 	public Object getPrimaryFrequency() {
 		if (frequencies.iterator().hasNext()) {
 			return frequencies.iterator().next();
@@ -97,7 +114,17 @@ public class HaplotypePair {
 		
 	}
 	
-	public HaplotypePair(Haplotype hap1, Haplotype hap2) {		
+	/**
+	 * Pairs two haplotypes and computes their combined frequency from each one's own
+	 * {@link Haplotype#getLinkage()} (if both are linked; otherwise this pair carries no
+	 * frequency). Which haplotype becomes {@code seq="1"} vs {@code seq="2"} is decided by
+	 * {@link HaplotypeComparator}, not argument order, so construction is deterministic
+	 * regardless of which haplotype the caller happens to pass first.
+	 *
+	 * @param hap1 one haplotype of the pair
+	 * @param hap2 the other haplotype of the pair
+	 */
+	public HaplotypePair(Haplotype hap1, Haplotype hap2) {
 		if (new HaplotypeComparator().compare(hap1, hap2) <= 0) {
 			hap1.setSequence(1);
 			haplotypes.add(hap1);

--- a/ld-validation/src/main/java/org/dash/valid/gl/haplo/MultiLocusHaplotype.java
+++ b/ld-validation/src/main/java/org/dash/valid/gl/haplo/MultiLocusHaplotype.java
@@ -33,6 +33,14 @@ import org.dash.valid.LocusComparator;
 import org.dash.valid.LocusSet;
 import org.dash.valid.gl.GLStringConstants;
 
+/**
+ * Concrete {@link Haplotype} spanning one or more loci — the implementation used
+ * throughout this project. {@link #getHaplotypeString()} and
+ * {@link #getFullHaplotypeString()} are built from a {@link LocusSet}/{@link LocusComparator}
+ * ordering rather than raw map iteration, specifically so they (and the
+ * {@code equals()}/{@code hashCode()} inherited from {@link Haplotype}, which are based on
+ * {@link #getHaplotypeString()}) are stable across JVM launches.
+ */
 public class MultiLocusHaplotype extends Haplotype {
 	private Map<Locus, List<String>> alleleMap = new ConcurrentHashMap<Locus, List<String>>();
 	private HashMap<Locus, Integer> haplotypeInstanceMap = new HashMap<Locus, Integer>();

--- a/ld-validation/src/main/java/org/dash/valid/report/DetectedDisequilibriumElement.java
+++ b/ld-validation/src/main/java/org/dash/valid/report/DetectedDisequilibriumElement.java
@@ -41,6 +41,19 @@ import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 
 
+/**
+ * A reference-data match found for one haplotype — the {@link DisequilibriumElement} it
+ * matched, plus the {@link Haplotype} it was matched for. Reported as {@code <linkage>} in
+ * output XML.
+ * <p>
+ * <b>Note:</b> this class overrides {@link #equals(Object)} (true for any two matches of
+ * the same reference row, regardless of which raw-allele candidate matched it) but not
+ * {@code hashCode()} — a real equals()/hashCode() contract violation, fixed at the call
+ * site rather than here (see {@link org.dash.valid.HLALinkageDisequilibrium}'s
+ * {@code findLinkedPairs}, which derives its linkages set directly from already-deterministic
+ * winners instead of ever putting these into a {@code HashSet}/{@code HashMap}). Do not add
+ * a new hash-based collection of these without accounting for that gap.
+ */
 @XmlRootElement(name="linkage")
 @XmlType(propOrder={"haplotype", "frequencies", "frequency"})
 public class DetectedDisequilibriumElement {


### PR DESCRIPTION
Class-level and public-method javadoc for the classes users/contributors actually touch, per the scope agreed for Phase 6c: `HLALinkageDisequilibrium` (the detection algorithm's public entry points), the `Haplotype`/`HaplotypePair`/`MultiLocusHaplotype`/`DisequilibriumElement`/`CoreDisequilibriumElement`/`DetectedDisequilibriumElement` model classes, and the `AnalyzeGLStrings`/`NormalizeFrequencyFile` CLI tools (`SyntheticGLStringGenerator` already had thorough class javadoc from Phase 5c). Deliberately not exhaustive — internal helpers and most getters/setters are left undocumented, per the agreed scope.

Documents several non-obvious things directly, rather than restating obvious signatures: the `value`/`fullValue` (G-group vs fully-expanded) distinction on `Haplotype`; `HaplotypePair`'s deterministic `seq=1`/`2` assignment via `HaplotypeComparator`, not construction-argument order; the ARS/G-group (not exact-string) basis of `DisequilibriumElement#equals`; and `DetectedDisequilibriumElement`'s known equals()-without-hashCode() gap, with a pointer to where it's actually worked around.

Found and fixed a real, unrelated bug while writing this: `NormalizeFrequencyFile`'s class javadoc was a copy-paste leftover literally reading "AnalyzeGLStrings".

**Verified:** the `javadoc` tool run directly (not just `javac`) against every touched file confirms zero broken `{@link}` references and zero missing main-description warnings on anything actually written (only expected "no comment" warnings on methods deliberately left undocumented). Full reactor `mvn clean verify` passes (50 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)