### PR TITLE
Remove the 200MB multipart upload cap

### DIFF
--- a/ld-service/src/main/resources/application.properties
+++ b/ld-service/src/main/resources/application.properties
@@ -1,13 +1,19 @@
 # Spring Boot's defaults (1MB per file, 10MB per request) reject exactly the uploads Phase 8's
 # frequencyFiles support exists for: real converted frequency reference data can run well over
-# 100MB (e.g. the 2026 NMDP nine-locus Zenodo release, ~150-180MB for some locus combinations --
-# see the modernization tracker). Raised generously rather than tightly, matching what the CLI's
-# -q/-l flags already handle with no size constraint at all; ld-service is scoped as a
-# personal/local tool, not a publicly-exposed service, so a generous cap isn't a meaningful
-# resource-exhaustion risk here.
-spring.servlet.multipart.max-file-size=200MB
-spring.servlet.multipart.max-request-size=200MB
+# 100MB, and this project's own larger converted datasets (the 2026 NMDP nine-locus release --
+# see the modernization tracker) run up to ~1.02GB for some locus combinations. An earlier fixed
+# cap of 200MB here already turned out too small once we measured actual file sizes, and any
+# other fixed number just relocates the same cliff -- there's no natural ceiling to pick, since
+# it tracks whatever locus combination NMDP publishes next. Unlimited (-1) matches what the CLI's
+# -q/-l flags already do with no size constraint at all; ld-service is scoped as a personal/local
+# tool, not a publicly-exposed service (see README's "Requests are serialized" note), so removing
+# the cap isn't a meaningful resource-exhaustion risk here. Upload handling itself streams
+# disk-to-disk (MultipartFile#transferTo in GenotypesApiController, not an in-memory read), so
+# there's no separate memory ceiling forcing a smaller number regardless.
+spring.servlet.multipart.max-file-size=-1
+spring.servlet.multipart.max-request-size=-1
 
 # Embedded Tomcat has its own, separate post-size cap (default 2MB) that rejects large multipart
-# bodies before Spring's own multipart settings above are ever consulted.
-server.tomcat.max-http-form-post-size=200MB
+# bodies before Spring's own multipart settings above are ever consulted. -1 disables it the same
+# way as the two settings above.
+server.tomcat.max-http-form-post-size=-1


### PR DESCRIPTION
## Why

Phase 8's async job API raised the multipart limit to 200MB, but that was picked before we'd measured real file sizes. This project's own converted NMDP frequency datasets (2026 nine-locus release) run up to ~1.02GB for some locus combinations — comfortably over the cap.

## What changed

`ld-service/src/main/resources/application.properties`: `spring.servlet.multipart.max-file-size`, `spring.servlet.multipart.max-request-size`, and `server.tomcat.max-http-form-post-size` all set to `-1` (unlimited) instead of another fixed number, since there's no natural ceiling to pick — it just tracks whatever locus combination NMDP publishes next.

This matches the CLI's own `-q`/`-l` flags, which have never had a size constraint, and is consistent with `ld-service`'s existing scope as a personal/local tool, not a publicly-exposed service (already documented in the README). Upload handling streams disk-to-disk (`MultipartFile#transferTo`), so there's no memory ceiling forcing a smaller number either.

## Verification

Full `ld-service` test suite passes, including the real embedded-Tomcat tests (`GenotypesFileJobIntegrationTest`, `StaticUiTest`) that load this exact config at startup — confirms `-1` is valid for both Spring's multipart resolver and Tomcat's post-size cap, not just that the property parses.

Part of the Phase 8 batch (fork-only for now, per the existing batching plan — not pushed upstream with this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)