### PR TITLE
Clamp relative-frequency to 100.0 to fix floating-point overrun

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/report/DetectedLinkageFindings.java
+++ b/ld-validation/src/main/java/org/dash/valid/report/DetectedLinkageFindings.java
@@ -207,15 +207,19 @@ public class DetectedLinkageFindings {
 										
 					totalFreq = raceTotalFreqsMap.get(loci).get(relativeRaceFreq.getRace());
 
-					// Clamped to 100.0: relativeFrequency is this pair's own contribution to totalFreq,
-					// which by definition can be at most the whole of totalFreq -- but (freq * 100) / total
-					// is two independently-rounded double operations, and double rounding doesn't
-					// guarantee round-tripping back to exactly 100.0 even when freq == totalFreq (a
-					// single-candidate race bucket, the common case). Confirmed against real output
-					// (analyze-gl-strings against stanfordExamplesFixed.txt): 391 of 10173 values came
-					// back as exactly 100.00000000000001 -- one ULP over 100, not a genuine case of one
-					// candidate outweighing the total it belongs to.
-					relativeRaceFreq.setRelativeFrequency(Math.min(100.0, (relativeRaceFreq.getFrequency() * 100) / totalFreq));
+					// relativeFrequency is this pair's own contribution to totalFreq, which by definition
+					// can be at most the whole of totalFreq -- freq/totalFreq can never round to more than
+					// 1.0 (dividing two doubles where the numerator is <= the denominator is bounded above
+					// by 1.0, which is itself exactly representable), and multiplying that by the exactly-
+					// representable 100.0 can't push it past 100.0 either. Divide-then-multiply matters here,
+					// not just style: the more obvious (freq * 100) / total is two *independently* rounded
+					// operations that don't reliably round-trip back to exactly 100.0 even when freq ==
+					// totalFreq (a single-candidate race bucket, the common case) -- confirmed against real
+					// output (analyze-gl-strings against stanfordExamplesFixed.txt): 391 of 10173 values came
+					// back as exactly 100.00000000000001 (one ULP over), and plenty of others landed a ULP
+					// under (e.g. 99.99999999999999) from the same rounding, just in the other direction.
+					// Math.min(100.0, ...) is kept as a zero-cost defensive backstop, not the actual fix.
+					relativeRaceFreq.setRelativeFrequency(Math.min(100.0, 100.0 * (relativeRaceFreq.getFrequency() / totalFreq)));
 					freqsByRace.add(relativeRaceFreq);
 					
 					List<Double> relativeFrequencies;

--- a/ld-validation/src/main/java/org/dash/valid/report/DetectedLinkageFindings.java
+++ b/ld-validation/src/main/java/org/dash/valid/report/DetectedLinkageFindings.java
@@ -206,8 +206,16 @@ public class DetectedLinkageFindings {
 					relativeRaceFreq = (RelativeFrequencyByRace) freqByRace;
 										
 					totalFreq = raceTotalFreqsMap.get(loci).get(relativeRaceFreq.getRace());
-					
-					relativeRaceFreq.setRelativeFrequency((relativeRaceFreq.getFrequency() * 100) / totalFreq);
+
+					// Clamped to 100.0: relativeFrequency is this pair's own contribution to totalFreq,
+					// which by definition can be at most the whole of totalFreq -- but (freq * 100) / total
+					// is two independently-rounded double operations, and double rounding doesn't
+					// guarantee round-tripping back to exactly 100.0 even when freq == totalFreq (a
+					// single-candidate race bucket, the common case). Confirmed against real output
+					// (analyze-gl-strings against stanfordExamplesFixed.txt): 391 of 10173 values came
+					// back as exactly 100.00000000000001 -- one ULP over 100, not a genuine case of one
+					// candidate outweighing the total it belongs to.
+					relativeRaceFreq.setRelativeFrequency(Math.min(100.0, (relativeRaceFreq.getFrequency() * 100) / totalFreq));
 					freqsByRace.add(relativeRaceFreq);
 					
 					List<Double> relativeFrequencies;

--- a/ld-validation/src/test/java/org/dash/valid/report/DetectedLinkageFindingsTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/report/DetectedLinkageFindingsTest.java
@@ -45,20 +45,35 @@ import org.junit.jupiter.api.Test;
 // 100.00000000000001). Root cause, confirmed independently in Python before fixing here: for any
 // double x, (x * 100.0) / x is NOT guaranteed to round-trip to exactly 100.0 -- the multiply and
 // divide are two separately-rounded IEEE-754 operations, so this happens for a meaningful fraction
-// of possible x values (~6.5% in a random sample), even in the simplest case (a race with only one
-// candidate haplotype pair, so that pair's own frequency *is* totalFreq). Not a logic bug -- a
-// relativeFrequency can never legitimately exceed the total it's a share of -- just floating-point
-// noise on the order of 1 ULP that DetectedLinkageFindings#setLinkedPairs now clamps away.
+// of possible x values (~6.5% each direction in a random sample), even in the simplest case (a race
+// with only one candidate haplotype pair, so that pair's own frequency *is* totalFreq). Not a logic
+// bug -- a single candidate's relative frequency against its own total must be exactly 100.0 -- just
+// floating-point noise of about 1 ULP, landing on either side of 100.0 with similar likelihood.
+// DetectedLinkageFindings#setLinkedPairs now divides before multiplying by 100.0 instead of after,
+// which (confirmed the same way) lands on exactly 100.0 every time for this case, in addition to the
+// Math.min(100.0, ...) backstop for the general (non-degenerate) case.
 public class DetectedLinkageFindingsTest {
 
-	// Found via a random search in Python: (x * 100.0) / x == 100.00000000000001 for this x,
-	// reproducing the exact artifact seen in the user's real output.
-	private static final double FREQUENCY_THAT_ROUNDS_OVER_100_PRE_FIX = 0.43276707357738264;
+	// Found via random searches in Python: (x * 100.0) / x landed just over 100.0 for one value and
+	// just under for the other, reproducing both directions of the artifact seen in the user's real
+	// output -- 100.00000000000001 was the exact value found in summary.xml; the under-100 value is
+	// the same phenomenon in the other direction, not itself something seen in that file.
+	private static final double FREQUENCY_THAT_ROUNDED_OVER_100_PRE_FIX = 0.43276707357738264;
+	private static final double FREQUENCY_THAT_ROUNDED_UNDER_100_PRE_FIX = 0.7637746213388679;
 
 	@Test
-	public void testRelativeFrequencyIsClampedTo100ForASingleCandidatePair() {
+	public void testRelativeFrequencyIsExactly100ForASingleCandidatePairThatPreFixRoundedOver() {
+		assertEquals(100.0, relativeFrequencyForSingleCandidatePair(FREQUENCY_THAT_ROUNDED_OVER_100_PRE_FIX));
+	}
+
+	@Test
+	public void testRelativeFrequencyIsExactly100ForASingleCandidatePairThatPreFixRoundedUnder() {
+		assertEquals(100.0, relativeFrequencyForSingleCandidatePair(FREQUENCY_THAT_ROUNDED_UNDER_100_PRE_FIX));
+	}
+
+	private static double relativeFrequencyForSingleCandidatePair(double frequency) {
 		MultiLocusHaplotype hap1 = haplotype("HLA-B*07:04", "HLA-C*07:02", withFrequency(1.0));
-		MultiLocusHaplotype hap2 = haplotype("HLA-B*44:03", "HLA-C*12:03", withFrequency(FREQUENCY_THAT_ROUNDS_OVER_100_PRE_FIX));
+		MultiLocusHaplotype hap2 = haplotype("HLA-B*44:03", "HLA-C*12:03", withFrequency(frequency));
 
 		HaplotypePair pair = new HaplotypePair(hap1, hap2);
 		assertTrue(pair.isByRace());
@@ -70,13 +85,7 @@ public class DetectedLinkageFindingsTest {
 		findings.setLinkedPairs(linkedPairs);
 
 		RelativeFrequencyByRace relativeFrequencyByRace = pair.getFrequencies().iterator().next();
-
-		// Pre-fix, this pair's own (and only) contribution to its race's total came back as
-		// 100.00000000000001 -- reproduced independently above and confirmed to still reproduce
-		// without the Math.min(100.0, ...) clamp in DetectedLinkageFindings#setLinkedPairs.
-		assertEquals(100.0, relativeFrequencyByRace.getRelativeFrequency(),
-				"a single candidate pair is its race's entire total, so its relative frequency must be exactly 100.0, "
-				+ "not a hair over it from floating-point rounding");
+		return relativeFrequencyByRace.getRelativeFrequency();
 	}
 
 	private static MultiLocusHaplotype haplotype(String bAllele, String cAllele, List<FrequencyByRace> frequenciesByRace) {

--- a/ld-validation/src/test/java/org/dash/valid/report/DetectedLinkageFindingsTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/report/DetectedLinkageFindingsTest.java
@@ -1,0 +1,110 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.dash.valid.Locus;
+import org.dash.valid.gl.haplo.HaplotypePair;
+import org.dash.valid.gl.haplo.HaplotypePairComparator;
+import org.dash.valid.gl.haplo.HaplotypePairSet;
+import org.dash.valid.gl.haplo.MultiLocusHaplotype;
+import org.dash.valid.race.DisequilibriumElementByRace;
+import org.dash.valid.race.FrequencyByRace;
+import org.dash.valid.race.RelativeFrequencyByRace;
+import org.junit.jupiter.api.Test;
+
+// Regression test for a real user-reported bug: analyze-gl-strings against stanfordExamplesFixed.txt
+// produced relative-frequency values > 100 in summary.xml (391 of 10173, all exactly
+// 100.00000000000001). Root cause, confirmed independently in Python before fixing here: for any
+// double x, (x * 100.0) / x is NOT guaranteed to round-trip to exactly 100.0 -- the multiply and
+// divide are two separately-rounded IEEE-754 operations, so this happens for a meaningful fraction
+// of possible x values (~6.5% in a random sample), even in the simplest case (a race with only one
+// candidate haplotype pair, so that pair's own frequency *is* totalFreq). Not a logic bug -- a
+// relativeFrequency can never legitimately exceed the total it's a share of -- just floating-point
+// noise on the order of 1 ULP that DetectedLinkageFindings#setLinkedPairs now clamps away.
+public class DetectedLinkageFindingsTest {
+
+	// Found via a random search in Python: (x * 100.0) / x == 100.00000000000001 for this x,
+	// reproducing the exact artifact seen in the user's real output.
+	private static final double FREQUENCY_THAT_ROUNDS_OVER_100_PRE_FIX = 0.43276707357738264;
+
+	@Test
+	public void testRelativeFrequencyIsClampedTo100ForASingleCandidatePair() {
+		MultiLocusHaplotype hap1 = haplotype("HLA-B*07:04", "HLA-C*07:02", withFrequency(1.0));
+		MultiLocusHaplotype hap2 = haplotype("HLA-B*44:03", "HLA-C*12:03", withFrequency(FREQUENCY_THAT_ROUNDS_OVER_100_PRE_FIX));
+
+		HaplotypePair pair = new HaplotypePair(hap1, hap2);
+		assertTrue(pair.isByRace());
+
+		Set<HaplotypePair> linkedPairs = new HaplotypePairSet(new HaplotypePairComparator());
+		linkedPairs.add(pair);
+
+		DetectedLinkageFindings findings = new DetectedLinkageFindings();
+		findings.setLinkedPairs(linkedPairs);
+
+		RelativeFrequencyByRace relativeFrequencyByRace = pair.getFrequencies().iterator().next();
+
+		// Pre-fix, this pair's own (and only) contribution to its race's total came back as
+		// 100.00000000000001 -- reproduced independently above and confirmed to still reproduce
+		// without the Math.min(100.0, ...) clamp in DetectedLinkageFindings#setLinkedPairs.
+		assertEquals(100.0, relativeFrequencyByRace.getRelativeFrequency(),
+				"a single candidate pair is its race's entire total, so its relative frequency must be exactly 100.0, "
+				+ "not a hair over it from floating-point rounding");
+	}
+
+	private static MultiLocusHaplotype haplotype(String bAllele, String cAllele, List<FrequencyByRace> frequenciesByRace) {
+		ConcurrentHashMap<Locus, List<String>> alleleMap = new ConcurrentHashMap<Locus, List<String>>();
+		alleleMap.put(Locus.HLA_B, list(bAllele));
+		alleleMap.put(Locus.HLA_C, list(cAllele));
+
+		MultiLocusHaplotype haplotype = new MultiLocusHaplotype(alleleMap, new HashMap<Locus, Integer>(), false);
+
+		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
+		hlaElementMap.put(Locus.HLA_B, list(bAllele));
+		hlaElementMap.put(Locus.HLA_C, list(cAllele));
+
+		DisequilibriumElementByRace disequilibriumElementByRace = new DisequilibriumElementByRace(hlaElementMap, frequenciesByRace);
+		haplotype.setLinkage(new DetectedDisequilibriumElement(disequilibriumElementByRace));
+
+		return haplotype;
+	}
+
+	private static List<FrequencyByRace> withFrequency(double frequency) {
+		List<FrequencyByRace> frequenciesByRace = new ArrayList<FrequencyByRace>();
+		frequenciesByRace.add(new FrequencyByRace(frequency, "1", "CAU"));
+		return frequenciesByRace;
+	}
+
+	private static List<String> list(String allele) {
+		List<String> alleles = new ArrayList<String>();
+		alleles.add(allele);
+		return alleles;
+	}
+}


### PR DESCRIPTION
## The bug

Reported against real data: running `analyze-gl-strings` against `stanfordExamplesFixed.txt` produced `relative-frequency` values over 100 in `summary.xml` — 391 of 10,173 entries, all exactly `100.00000000000001`.

## Root cause

`relativeFrequency` is a candidate's own frequency divided into the sum of every candidate sharing its race+locus bucket ([DetectedLinkageFindings.java](ld-validation/src/main/java/org/dash/valid/report/DetectedLinkageFindings.java)). Mathematically, a share of a total can never exceed the total — floating-point addition of non-negative doubles is monotonic, so the total is provably `>=` any single addend that went into it.

But `(freq * 100) / totalFreq` is two *independently rounded* IEEE-754 operations, and dividing back out doesn't reliably round-trip to exactly `100.0` — even in the simplest case, a single candidate whose own frequency *is* the whole total. Confirmed against 2 million random doubles in Python: `(x * 100.0) / x` lands away from `100.0` about 13% of the time, split roughly evenly between just-over (`100.00000000000001`, matching the real output exactly) and just-under (e.g. `99.99999999999999`).

## Fix

Reordered to divide first, then multiply by `100.0`, instead of multiply-then-divide. Verified in Python: the reordered formula lands on exactly `100.0` 100% of the time for the degenerate single-candidate case (200K trials), and never exceeds `100.0` for the general multi-candidate case either (500K trials) — expected, since dividing a value by a sum that includes it rounds to at most exactly `1.0` (itself exactly representable), and multiplying by the exactly-representable `100.0` can't push it over. `Math.min(100.0, ...)` is kept as a zero-cost defensive backstop, not the actual fix.

## Verification

- `DetectedLinkageFindingsTest` covers both directions: a frequency found (via the same Python search) to round just *over* 100.0 pre-fix, and one that rounds just *under* — both assert exactly `100.0` post-fix.
- Verified each test fails with the pre-fix formula reproducing the real artifact (`100.00000000000001` / `99.99999999999999`) via `git stash`, and passes with the fix restored.
- Full `ld-validation` suite and full reactor build (`mvn install`) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)