### PR TITLE
Avoid copying the full reference list per candidate haplotype

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
+++ b/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
@@ -182,7 +182,15 @@ public class HLALinkageDisequilibrium {
 		MultiLocusHaplotype enrichedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(haplotype.getAlleleMap()), 
 				new HashMap<Locus, Integer>(haplotype.getHaplotypeInstanceMap()), haplotype.getDrb345Homozygous());
 		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
-		List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
+		// Was: new ArrayList<>(disequilibriumElements) -- a full copy of the (potentially huge,
+		// e.g. 900K+ rows for a real custom-uploaded frequency file) reference list, made fresh
+		// for every single haplotype checked. disequilibriumElements is HLAFrequenciesLoader's
+		// own live, shared list (see #getDisequilibriumElements) -- callers here only ever read
+		// from shortenedList (.contains()/.indexOf()/.get()/.subList()), never mutate it, so
+		// there's nothing the copy was protecting against. A subList() view (or, as here, the
+		// list itself, since subList() start=0 is just the list) behaves identically for every
+		// operation this method performs, without allocating and copying the whole thing.
+		List<DisequilibriumElement> shortenedList = disequilibriumElements;
 
 		for (Locus locus : enrichedHaplotype.getLoci()) {
 			if (loci.contains(locus)) {
@@ -238,7 +246,11 @@ public class HLALinkageDisequilibrium {
 		MultiLocusHaplotype clonedHaplotype = null;
 
 		for (MultiLocusHaplotype possibleHaplotype : glString.getPossibleHaplotypes(loci)) {
-			List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
+			// See the identical comment in enrichHaplotype() above: this used to copy the full
+			// (potentially huge) reference list per candidate haplotype for no reason -- nothing
+			// here mutates shortenedList, so referencing disequilibriumElements directly is
+			// behaviorally identical and avoids that copy.
+			List<DisequilibriumElement> shortenedList = disequilibriumElements;
 
 			HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
 


### PR DESCRIPTION
## What

`findLinkedPairs()` and `enrichHaplotype()` in `HLALinkageDisequilibrium` each did `new ArrayList<>(disequilibriumElements)` — a full copy of the reference frequency list (can be 900K+ rows for a real custom-uploaded file) — for **every single candidate haplotype** checked. Both methods only ever read from the result (`.contains()`/`.indexOf()`/`.get()`/`.subList()`); nothing mutates it, so the copy was pure waste. Using the list directly is behaviorally identical.

## Context

Found while investigating real, user-reported slowness running `analyze-gl-strings` against a large custom frequency file (927K rows). This fix alone is **not sufficient** to fix that slowness — the remaining bottleneck is the O(n) linear scan itself (`.contains()`/`.indexOf()`), not the copy, confirmed by benchmarking before/after against the real pathological case. That's a separate, larger fix (replacing the scan with an index that respects `DisequilibriumElement`'s fuzzy ARS/field-truncation matching semantics), tracked as its own follow-up given the correctness stakes of touching this code.

This commit stands on its own regardless — it's a real, zero-risk reduction in redundant work with no behavior change.

## Verification

Full `ld-validation` test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)