### PR TITLE
Index DisequilibriumElement matching instead of a linear scan

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/DisequilibriumElementIndex.java
+++ b/ld-validation/src/main/java/org/dash/valid/DisequilibriumElementIndex.java
@@ -1,0 +1,300 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.dash.valid.ars.AntigenRecognitionSiteLoader;
+import org.dash.valid.gl.GLStringConstants;
+import org.dash.valid.gl.GLStringUtilities;
+
+/**
+ * Accelerates {@link DisequilibriumElement#equals(Object)} lookups against a (potentially very
+ * large, e.g. 900K+ rows for a real custom-uploaded frequency file) reference list, without
+ * changing what counts as a match.
+ * <p>
+ * {@code equals()}'s notion of "match" per locus is the OR of two independent, non-exact-string
+ * comparisons -- {@link GLStringUtilities#fieldLevelComparison} (colon-field prefix truncation,
+ * to whichever side has fewer fields) and {@link GLStringUtilities#checkAntigenRecognitionSite}
+ * (ARS/G-group membership) -- so a plain {@code Map<String, DisequilibriumElement>} keyed by
+ * allele string would silently miss real matches. This class instead builds, per locus:
+ * <ul>
+ * <li>a field-prefix index covering every reference row at every truncation depth its own
+ *     allele string supports, so a query allele of any length finds every row whose comparison
+ *     (at whichever length is shorter) would agree; and</li>
+ * <li>an ARS-code index, inverting {@link AntigenRecognitionSiteLoader}'s existing map against
+ *     the reference rows actually present.</li>
+ * </ul>
+ * A query's per-locus candidate sets (built from these indexes) are intersected across the
+ * query's own locus set, exactly mirroring {@code equals()}'s per-locus AND -- including the
+ * DRB345 homozygous dash/{@code NNNN} special case, precomputed once since it only ever depends
+ * on the reference data, not the query. The surviving candidates are then confirmed with the
+ * real {@code equals()} before being returned, so an indexing mistake can only cost speed, never
+ * silently produce a wrong match.
+ * <p>
+ * Built once per distinct reference list (identity-cached, not equals()/hashCode()-cached --
+ * {@code DisequilibriumElement} intentionally has no {@code hashCode()}, see its {@code equals()}
+ * javadoc) and reused across every candidate haplotype and every genotype checked against that
+ * same list within a run. {@link org.dash.valid.freq.HLAFrequenciesLoader#reset()} always
+ * installs a brand new list rather than mutating the old one in place, so a plain identity cache
+ * here needs no explicit invalidation -- a reset simply makes the old cache entry unreachable.
+ */
+class DisequilibriumElementIndex {
+	private static final Logger LOGGER = Logger.getLogger(DisequilibriumElementIndex.class.getName());
+
+	private static final Map<List<DisequilibriumElement>, DisequilibriumElementIndex> CACHE =
+			new IdentityHashMap<List<DisequilibriumElement>, DisequilibriumElementIndex>();
+
+	private final List<DisequilibriumElement> elements;
+
+	// locus -> fieldCount -> "this row's own first fieldCount fields" -> row indices.
+	// Populated for every fieldCount from 1 up to each row's own full field count, so a row's
+	// entry at fieldCount == its own length is its "full string" entry (comparisonLength ==
+	// this row's length, the row is the shorter/equal side), and entries at fieldCount < its
+	// own length exist so a *shorter* query can still find it (comparisonLength == the query's
+	// length, this row is the longer side but truncates down to match).
+	private final Map<Locus, Map<Integer, Map<String, List<Integer>>>> ownLengthIndex =
+			new HashMap<Locus, Map<Integer, Map<String, List<Integer>>>>();
+
+	private final Map<Locus, Map<String, List<Integer>>> arsIndex =
+			new HashMap<Locus, Map<String, List<Integer>>>();
+
+	// Rows whose DRB345 allele list contains the "no DRB345 gene" placeholder (DASH or NNNN) --
+	// the only rows the DRB345-homozygous special case in equals() can ever bypass a match for.
+	// Reference DisequilibriumElements never carry a Haplotype of their own (HLAFrequenciesLoader
+	// never calls setHaplotype() when building them -- confirmed by reading it), so the special
+	// case's *other* clause (checking element1's own haplotype) never applies to reference rows;
+	// only the query's own getDrb345Homozygous() flag matters here.
+	private final Set<Integer> drb345PlaceholderRows = new LinkedHashSet<Integer>();
+
+	private DisequilibriumElementIndex(List<DisequilibriumElement> elements) {
+		this.elements = elements;
+		build();
+	}
+
+	static synchronized DisequilibriumElementIndex forElements(List<DisequilibriumElement> elements) {
+		DisequilibriumElementIndex index = CACHE.get(elements);
+
+		if (index == null) {
+			index = new DisequilibriumElementIndex(elements);
+			CACHE.put(elements, index);
+		}
+
+		return index;
+	}
+
+	private void build() {
+		HashMap<String, HashSet<String>> arsMap;
+
+		try {
+			arsMap = AntigenRecognitionSiteLoader.getInstance().getArsMap();
+		}
+		catch (IOException | InvalidFormatException e) {
+			LOGGER.warning("Could not load ars data while building DisequilibriumElementIndex.");
+			arsMap = new HashMap<String, HashSet<String>>();
+		}
+
+		for (int rowIndex = 0; rowIndex < elements.size(); rowIndex++) {
+			DisequilibriumElement row = elements.get(rowIndex);
+
+			for (Locus locus : row.getLoci()) {
+				List<String> alleles = row.getHlaElement(locus);
+
+				if (alleles == null) {
+					continue;
+				}
+
+				for (String allele : alleles) {
+					indexFieldPrefixes(locus, allele, rowIndex);
+					indexArsCodes(arsMap, locus, allele, rowIndex);
+
+					if (Locus.isDRB345(locus) && (GLStringConstants.DASH.equals(allele) || GLStringConstants.NNNN.equals(allele))) {
+						drb345PlaceholderRows.add(rowIndex);
+					}
+				}
+			}
+		}
+	}
+
+	private void indexFieldPrefixes(Locus locus, String allele, int rowIndex) {
+		String[] fields = allele.split(GLStringUtilities.COLON);
+		Map<Integer, Map<String, List<Integer>>> byLength = ownLengthIndex.get(locus);
+
+		if (byLength == null) {
+			byLength = new HashMap<Integer, Map<String, List<Integer>>>();
+			ownLengthIndex.put(locus, byLength);
+		}
+
+		StringBuilder prefix = new StringBuilder();
+		for (int fieldCount = 1; fieldCount <= fields.length; fieldCount++) {
+			if (fieldCount > 1) {
+				prefix.append(GLStringUtilities.COLON);
+			}
+			prefix.append(fields[fieldCount - 1]);
+
+			Map<String, List<Integer>> byPrefix = byLength.get(fieldCount);
+			if (byPrefix == null) {
+				byPrefix = new HashMap<String, List<Integer>>();
+				byLength.put(fieldCount, byPrefix);
+			}
+
+			addIndexEntry(byPrefix, prefix.toString(), rowIndex);
+		}
+	}
+
+	private void indexArsCodes(HashMap<String, HashSet<String>> arsMap, Locus locus, String allele, int rowIndex) {
+		HashSet<String> codes = arsMap.get(allele);
+
+		if (codes == null) {
+			return;
+		}
+
+		Map<String, List<Integer>> byCode = arsIndex.get(locus);
+		if (byCode == null) {
+			byCode = new HashMap<String, List<Integer>>();
+			arsIndex.put(locus, byCode);
+		}
+
+		for (String code : codes) {
+			addIndexEntry(byCode, code, rowIndex);
+		}
+	}
+
+	private static void addIndexEntry(Map<String, List<Integer>> index, String key, int rowIndex) {
+		List<Integer> rowIndices = index.get(key);
+		if (rowIndices == null) {
+			rowIndices = new ArrayList<Integer>();
+			index.put(key, rowIndices);
+		}
+		// Reference data is loaded with one entry per unique G-group string (see
+		// HLAFrequenciesLoader#loadStandardReferenceData), so in practice this list rarely grows
+		// past one -- but nothing here assumes that.
+		if (rowIndices.isEmpty() || !rowIndices.get(rowIndices.size() - 1).equals(rowIndex)) {
+			rowIndices.add(rowIndex);
+		}
+	}
+
+	/**
+	 * All elements of the original list that {@code query.equals(element)} would return true
+	 * for, in the original list's order -- exactly what a forward scan with
+	 * {@code List#indexOf}/{@code List#subList} would have found, just without doing one.
+	 * Every candidate the index surfaces is confirmed with the real {@code equals()} before
+	 * being included.
+	 */
+	List<DisequilibriumElement> findMatches(DisequilibriumElement query) {
+		Set<Integer> candidateIndices = null;
+
+		for (Locus locus : query.getLoci()) {
+			Set<Integer> locusMatches = matchesAtLocus(query, locus);
+
+			if (candidateIndices == null) {
+				candidateIndices = locusMatches;
+			}
+			else {
+				candidateIndices.retainAll(locusMatches);
+			}
+
+			if (candidateIndices.isEmpty()) {
+				return Collections.emptyList();
+			}
+		}
+
+		if (candidateIndices == null) {
+			return Collections.emptyList();
+		}
+
+		List<Integer> sortedIndices = new ArrayList<Integer>(candidateIndices);
+		Collections.sort(sortedIndices);
+
+		List<DisequilibriumElement> verified = new ArrayList<DisequilibriumElement>();
+		for (Integer rowIndex : sortedIndices) {
+			DisequilibriumElement candidate = elements.get(rowIndex);
+			// Defense in depth: the index is only ever used to narrow down which rows are worth
+			// checking. The real equals() -- the actual, unmodified source of truth -- still
+			// decides whether each one really matches.
+			if (query.equals(candidate)) {
+				verified.add(candidate);
+			}
+		}
+
+		return verified;
+	}
+
+	private Set<Integer> matchesAtLocus(DisequilibriumElement query, Locus locus) {
+		Set<Integer> locusMatches = new LinkedHashSet<Integer>();
+		List<String> queryAlleles = query.getHlaElement(locus);
+
+		if (queryAlleles != null) {
+			Map<Integer, Map<String, List<Integer>>> byLength = ownLengthIndex.get(locus);
+			Map<String, List<Integer>> byArsCode = arsIndex.get(locus);
+
+			for (String queryAllele : queryAlleles) {
+				String[] fields = queryAllele.split(GLStringUtilities.COLON);
+
+				if (byLength != null) {
+					StringBuilder prefix = new StringBuilder();
+					for (int fieldCount = 1; fieldCount <= fields.length; fieldCount++) {
+						if (fieldCount > 1) {
+							prefix.append(GLStringUtilities.COLON);
+						}
+						prefix.append(fields[fieldCount - 1]);
+
+						Map<String, List<Integer>> byPrefix = byLength.get(fieldCount);
+						if (byPrefix != null) {
+							List<Integer> hits = byPrefix.get(prefix.toString());
+							if (hits != null) {
+								locusMatches.addAll(hits);
+							}
+						}
+					}
+				}
+
+				if (byArsCode != null) {
+					String matchedValue = GLStringUtilities.convertToProteinLevel(queryAllele);
+					if (matchedValue != null) {
+						List<Integer> hits = byArsCode.get(matchedValue);
+						if (hits != null) {
+							locusMatches.addAll(hits);
+						}
+					}
+				}
+			}
+		}
+
+		if (Locus.isDRB345(locus) && query.getHaplotype() != null && query.getHaplotype().getDrb345Homozygous()) {
+			locusMatches.addAll(drb345PlaceholderRows);
+		}
+
+		return locusMatches;
+	}
+}

--- a/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
+++ b/ld-validation/src/main/java/org/dash/valid/HLALinkageDisequilibrium.java
@@ -179,10 +179,9 @@ public class HLALinkageDisequilibrium {
 	 * @return a copy of {@code haplotype}, annotated with a linkage if one was found
 	 */
 	public static Haplotype enrichHaplotype(EnumSet<Locus> loci, List<DisequilibriumElement> disequilibriumElements, Haplotype haplotype) {
-		MultiLocusHaplotype enrichedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(haplotype.getAlleleMap()), 
+		MultiLocusHaplotype enrichedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(haplotype.getAlleleMap()),
 				new HashMap<Locus, Integer>(haplotype.getHaplotypeInstanceMap()), haplotype.getDrb345Homozygous());
 		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
-		List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
 
 		for (Locus locus : enrichedHaplotype.getLoci()) {
 			if (loci.contains(locus)) {
@@ -192,21 +191,25 @@ public class HLALinkageDisequilibrium {
 				enrichedHaplotype.removeAlleles(locus);
 			}
 		}
-		
+
 		DisequilibriumElement element = new CoreDisequilibriumElement(hlaElementMap, enrichedHaplotype);
-		DetectedDisequilibriumElement detectedElement = null;
-					
-		while (shortenedList.contains(element)) {
-			int index = shortenedList.indexOf(element);
-			detectedElement = new DetectedDisequilibriumElement(shortenedList.get(index));
+
+		// Was a manual List#contains()/indexOf()/subList() linear scan over the full (possibly
+		// 900K+ row, for a real custom-uploaded frequency file) reference list, repeated once per
+		// match found. DisequilibriumElementIndex finds the identical set of matches (equals()
+		// itself is unchanged and still has the final say -- see its javadoc) without scanning
+		// the whole list per lookup. Keeps the original's "last match found wins" behavior: the
+		// loop below overwrites the linkage on every iteration, same as the old while-loop did.
+		List<DisequilibriumElement> matches = DisequilibriumElementIndex.forElements(disequilibriumElements).findMatches(element);
+
+		for (DisequilibriumElement match : matches) {
+			DetectedDisequilibriumElement detectedElement = new DetectedDisequilibriumElement(match);
 			detectedElement.setHaplotype(element.getHaplotype());
 			enrichedHaplotype.setLinkage(detectedElement);
-			
-			shortenedList = shortenedList.subList(index + 1, shortenedList.size());
 		}
-		
+
 		enrichedHaplotype.setSequence(haplotype.getSequence());
-		
+
 		return enrichedHaplotype;
 	}
 	
@@ -237,9 +240,12 @@ public class HLALinkageDisequilibrium {
 
 		MultiLocusHaplotype clonedHaplotype = null;
 
-		for (MultiLocusHaplotype possibleHaplotype : glString.getPossibleHaplotypes(loci)) {
-			List<DisequilibriumElement> shortenedList = new ArrayList<DisequilibriumElement>(disequilibriumElements);
+		// disequilibriumElements can be huge (900K+ rows for a real custom-uploaded frequency
+		// file); the index below is built once (and cached by list identity) rather than once
+		// per possibleHaplotype the way the old List#contains()/indexOf() scan effectively was.
+		DisequilibriumElementIndex index = DisequilibriumElementIndex.forElements(disequilibriumElements);
 
+		for (MultiLocusHaplotype possibleHaplotype : glString.getPossibleHaplotypes(loci)) {
 			HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
 
 			for (Locus locus : possibleHaplotype.getLoci()) {
@@ -250,12 +256,15 @@ public class HLALinkageDisequilibrium {
 			}
 
 			DisequilibriumElement element = new CoreDisequilibriumElement(hlaElementMap, possibleHaplotype);
-			DetectedDisequilibriumElement detectedElement = null;
 
-			while (shortenedList.contains(element)) {
-				int index = shortenedList.indexOf(element);
+			// Was a manual List#contains()/indexOf()/subList() linear scan finding matches one at
+			// a time. index.findMatches() returns the identical set (equals() itself is
+			// unchanged -- see DisequilibriumElementIndex's javadoc for why a naive string-keyed
+			// Map isn't safe here) in the same list order, so this loop's tie-break behavior below
+			// is unchanged from the original while-loop's.
+			for (DisequilibriumElement match : index.findMatches(element)) {
 				clonedHaplotype = new MultiLocusHaplotype(new ConcurrentHashMap<Locus, List<String>>(possibleHaplotype.getAlleleMap()), possibleHaplotype.getHaplotypeInstanceMap(), possibleHaplotype.getDrb345Homozygous());
-				detectedElement = new DetectedDisequilibriumElement(shortenedList.get(index));
+				DetectedDisequilibriumElement detectedElement = new DetectedDisequilibriumElement(match);
 				detectedElement.setHaplotype(element.getHaplotype());
 				clonedHaplotype.setLinkage(detectedElement);
 
@@ -270,8 +279,6 @@ public class HLALinkageDisequilibrium {
 							+ clonedHaplotype.getFullHaplotypeString() + " over " + existingHaplotype.getFullHaplotypeString());
 					linkedHaplotypesByValue.put(haplotypeValue, clonedHaplotype);
 				}
-
-				shortenedList = shortenedList.subList(index + 1, shortenedList.size());
 			}
 		}
 

--- a/ld-validation/src/test/java/org/dash/valid/DisequilibriumElementIndexTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/DisequilibriumElementIndexTest.java
@@ -1,0 +1,241 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.dash.valid.ars.AntigenRecognitionSiteLoader;
+import org.dash.valid.base.BaseDisequilibriumElement;
+import org.dash.valid.gl.haplo.MultiLocusHaplotype;
+import org.junit.jupiter.api.Test;
+
+// DisequilibriumElementIndex replaces a manual List#contains()/indexOf() linear scan (see
+// HLALinkageDisequilibrium) with an index, specifically so it can be fast against a reference
+// list with 900K+ rows -- but DisequilibriumElement#equals() itself does fuzzy matching (colon-
+// field prefix truncation OR ARS/G-group membership per locus, not exact string comparison), so
+// the risk here isn't "did the copy-and-scan style change" but "does the index still find every
+// match the old brute-force scan would have, and nothing else." Every test below compares the
+// index's result against bruteForceMatches() -- a deliberately trivial, obviously-correct linear
+// filter using the same, unmodified equals() -- rather than asserting expected values by hand,
+// so what's actually being verified is "the index agrees with the ground truth," not "the index
+// agrees with what I assumed."
+public class DisequilibriumElementIndexTest {
+
+	@Test
+	public void testExactMatch() {
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, "HLA-A*01:01:01:01");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01:01:01");
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference));
+	}
+
+	@Test
+	public void testFieldTruncationMatchWhenQueryIsShorterThanReference() {
+		// Query has fewer fields than the reference row -- fieldLevelComparison truncates to the
+		// query's own (shorter) length, so this must still match.
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, "HLA-A*01:01:01:01");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01");
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference));
+	}
+
+	@Test
+	public void testFieldTruncationMatchWhenQueryIsLongerThanReference() {
+		// Reverse of the above -- reference row has fewer fields, so the comparison truncates
+		// down to *its* length instead.
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, "HLA-A*01:01");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01:05:01");
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference));
+	}
+
+	@Test
+	public void testGenuineNonMatch() {
+		// No field-level overlap at all -- must not match, proving the index doesn't over-match.
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, "HLA-A*02:01");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01");
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).isEmpty());
+	}
+
+	@Test
+	public void testMultiLocusRequiresAllLociToMatch() {
+		// Matches at HLA_B but not HLA_C -- the pair must not be reported as an overall match,
+		// same as equals()'s per-locus AND.
+		HashMap<Locus, List<String>> refMap = new HashMap<Locus, List<String>>();
+		refMap.put(Locus.HLA_B, list("HLA-B*07:02"));
+		refMap.put(Locus.HLA_C, list("HLA-C*07:02"));
+		DisequilibriumElement reference = new BaseDisequilibriumElement(refMap, "1", "note");
+
+		HashMap<Locus, List<String>> queryMap = new HashMap<Locus, List<String>>();
+		queryMap.put(Locus.HLA_B, list("HLA-B*07:02"));
+		queryMap.put(Locus.HLA_C, list("HLA-C*04:01"));
+		DisequilibriumElement query = new CoreDisequilibriumElement(queryMap, haplotype());
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).isEmpty());
+	}
+
+	@Test
+	public void testMultipleTiedMatchesAreAllFound() {
+		// Two distinct reference rows both matching the same (shorter) query -- findLinkedPairs'
+		// tie-break logic depends on finding *all* of them, not just the first encountered.
+		DisequilibriumElement reference1 = referenceRow(Locus.HLA_A, "HLA-A*01:01:01:01");
+		DisequilibriumElement reference2 = referenceRow(Locus.HLA_A, "HLA-A*01:01:01:02");
+		DisequilibriumElement query = queryElement(Locus.HLA_A, "HLA-A*01:01");
+
+		List<DisequilibriumElement> elements = Arrays.asList(reference1, reference2);
+		assertIndexAgreesWithBruteForce(elements, query);
+
+		List<DisequilibriumElement> matches = DisequilibriumElementIndex.forElements(elements).findMatches(query);
+		assertTrue(matches.contains(reference1));
+		assertTrue(matches.contains(reference2));
+		assertEquals(2, matches.size());
+	}
+
+	@Test
+	public void testDrb345HomozygousPlaceholderMatch() {
+		// A DRB345-homozygous query (no DRB3/4/5 gene at all) must match a reference row whose
+		// DRB345 slot is the "-" placeholder, even though the strings share no field-level prefix
+		// and aren't ARS-related -- the special case in equals() this exercises.
+		HashMap<Locus, List<String>> refMap = new HashMap<Locus, List<String>>();
+		refMap.put(Locus.HLA_DRB345, list(org.dash.valid.gl.GLStringConstants.DASH));
+		DisequilibriumElement reference = new BaseDisequilibriumElement(refMap, "1", "note");
+
+		HashMap<Locus, List<String>> queryMap = new HashMap<Locus, List<String>>();
+		queryMap.put(Locus.HLA_DRB345, list("HLA-DRB3*01:01:02:01"));
+		MultiLocusHaplotype homozygousHaplotype = haplotype();
+		homozygousHaplotype.setDRB345Homozygous(true);
+		DisequilibriumElement query = new CoreDisequilibriumElement(queryMap, homozygousHaplotype);
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference));
+	}
+
+	@Test
+	public void testArsOnlyMatchAgreesWithBruteForce() throws IOException, InvalidFormatException {
+		// Finds a real example, from the actually-loaded ARS reference data, of a query allele
+		// that matches a reference allele *only* via ARS/G-group membership -- i.e. one with no
+		// field-level prefix overlap at all -- rather than hand-picking a specific allele pair
+		// that could quietly go stale as IMGT/HLA data changes. Skips (rather than fails) if none
+		// is found, since that would say more about data/network availability in this environment
+		// than about the index itself.
+		HashMap<String, HashSet<String>> arsMap = AntigenRecognitionSiteLoader.getInstance().getArsMap();
+
+		String referenceAllele = null;
+		String queryAllele = null;
+		outer:
+		for (Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+			for (String code : entry.getValue()) {
+				if (!org.dash.valid.gl.GLStringUtilities.fieldLevelComparison(code, entry.getKey())) {
+					referenceAllele = entry.getKey();
+					queryAllele = code;
+					break outer;
+				}
+			}
+		}
+
+		assumeTrue(referenceAllele != null, "Could not find a real ARS-only example pair in the loaded reference data");
+
+		DisequilibriumElement reference = referenceRow(Locus.HLA_A, referenceAllele);
+		DisequilibriumElement query = queryElement(Locus.HLA_A, queryAllele);
+
+		assertIndexAgreesWithBruteForce(Arrays.asList(reference), query);
+		assertTrue(DisequilibriumElementIndex.forElements(Arrays.asList(reference)).findMatches(query).contains(reference),
+				"query " + queryAllele + " should have matched " + referenceAllele + " via ARS membership");
+	}
+
+	@Test
+	public void testAgainstALargerMixedReferenceList() {
+		// A broader sanity check with more rows and more variety (matching, non-matching, and
+		// differing field counts at the same locus) than the single-row cases above, still
+		// verified against the same brute-force oracle rather than hand-asserted expectations.
+		List<DisequilibriumElement> elements = new ArrayList<DisequilibriumElement>();
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*01:01:01:01"));
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*02:01:01:01"));
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*03:01"));
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*01:02"));
+		elements.add(referenceRow(Locus.HLA_A, "HLA-A*11:01:01:01"));
+
+		assertIndexAgreesWithBruteForce(elements, queryElement(Locus.HLA_A, "HLA-A*01:01"));
+		assertIndexAgreesWithBruteForce(elements, queryElement(Locus.HLA_A, "HLA-A*03:01:01:01"));
+		assertIndexAgreesWithBruteForce(elements, queryElement(Locus.HLA_A, "HLA-A*24:02"));
+	}
+
+	private static void assertIndexAgreesWithBruteForce(List<DisequilibriumElement> elements, DisequilibriumElement query) {
+		List<DisequilibriumElement> indexed = DisequilibriumElementIndex.forElements(elements).findMatches(query);
+		List<DisequilibriumElement> bruteForce = bruteForceMatches(elements, query);
+
+		assertEquals(bruteForce, indexed,
+				"indexed lookup must find exactly the same matches, in the same order, as a plain linear equals() scan");
+	}
+
+	// The oracle: exactly what the old code was doing conceptually (find every element the query
+	// equals(), in list order) -- obviously correct by inspection, since it's just equals() called
+	// directly against every candidate with no indexing involved at all.
+	private static List<DisequilibriumElement> bruteForceMatches(List<DisequilibriumElement> elements, DisequilibriumElement query) {
+		List<DisequilibriumElement> matches = new ArrayList<DisequilibriumElement>();
+		for (DisequilibriumElement element : elements) {
+			if (query.equals(element)) {
+				matches.add(element);
+			}
+		}
+		return matches;
+	}
+
+	private static DisequilibriumElement referenceRow(Locus locus, String allele) {
+		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
+		hlaElementMap.put(locus, list(allele));
+		return new BaseDisequilibriumElement(hlaElementMap, "1", "note");
+	}
+
+	private static DisequilibriumElement queryElement(Locus locus, String allele) {
+		HashMap<Locus, List<String>> hlaElementMap = new HashMap<Locus, List<String>>();
+		hlaElementMap.put(locus, list(allele));
+		return new CoreDisequilibriumElement(hlaElementMap, haplotype());
+	}
+
+	private static MultiLocusHaplotype haplotype() {
+		return new MultiLocusHaplotype(new java.util.concurrent.ConcurrentHashMap<Locus, List<String>>(), new HashMap<Locus, Integer>(), false);
+	}
+
+	private static List<String> list(String allele) {
+		List<String> alleles = new ArrayList<String>();
+		alleles.add(allele);
+		return alleles;
+	}
+}


### PR DESCRIPTION
## The bug

Running `analyze-gl-strings` against a real 927K-row custom frequency file took 60-150+ seconds *per genotype* — extrapolated, multiple hours for a 337-genotype input. Confirmed identical on both the CLI and `ld-service` via a controlled head-to-head test, so this was never a service-specific issue — see the discussion on [#30](https://github.com/mpresteg/ImmunogeneticDataTools/pull/30) for the investigation that led here.

## Root cause

`HLALinkageDisequilibrium#findLinkedPairs`/`enrichHaplotype`: for **every** candidate haplotype a genotype's own ambiguity enumerates, both methods did a full `List#contains()`/`indexOf()` linear scan against the entire reference list.

A naive `Map<String, DisequilibriumElement>` isn't a safe fix: `DisequilibriumElement#equals()` does fuzzy matching per locus — colon-field prefix truncation (`fieldLevelComparison`) OR ARS/G-group membership (`checkAntigenRecognitionSite`) — not exact string comparison, and has no `hashCode()` override at all. A string-keyed map would silently miss real matches the current scan correctly finds.

## Fix

`DisequilibriumElementIndex`: per locus, a field-prefix index (every reference row indexed at every truncation depth its own allele supports) plus an ARS-code index (inverting `AntigenRecognitionSiteLoader`'s existing map). A query's per-locus candidate sets are intersected across its own locus set — mirroring `equals()`'s per-locus AND exactly, including the DRB345 homozygous dash/`NNNN` special case. Every surviving candidate is still confirmed with the real, unmodified `equals()` before being returned — an indexing mistake can only cost speed, never silently produce a wrong match. Cached by reference-list identity, since `HLAFrequenciesLoader#reset()` always installs a new list rather than mutating the old one in place.

## Verification

- **`DisequilibriumElementIndexTest`**: every case (exact match, field-truncation both directions, a genuine non-match, multi-locus AND, multiple tied matches, the DRB345 special case, and a real ARS-only match found dynamically against the actually-loaded reference data) is checked against a brute-force oracle — a trivial linear `equals()` filter — rather than hand-asserted expected values. What's verified is "the index agrees with the ground truth," not "the index agrees with what I assumed."
- Full `ld-validation` suite passes **unchanged**, including the existing fixture-based regression tests that exercise real detection end-to-end (real field-level and ARS matching) against real bundled reference data — no detected-linkage outcome changed anywhere.
- **Real end-to-end benchmark**, same pathological case: per-genotype cost fell from 60-150+s to a sustained ~10-11s average over 114 genotypes / 21 minutes of continuous, monitored execution — stopped there once the improvement was clearly consistent across the whole run, not just an early burst. A real, sustained **5-10x** improvement.

Builds on [#30](https://github.com/mpresteg/ImmunogeneticDataTools/pull/30) (a smaller, independent zero-risk fix found during the same investigation) but doesn't depend on it — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)