### PR TITLE
Buffer ARS reference data before parsing, and cache it to disk

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
+++ b/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
@@ -1,0 +1,189 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.ars;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.dash.valid.gl.GLStringConstants;
+
+/**
+ * Local, on-disk cache for {@link AntigenRecognitionSiteLoader}'s parsed ARS/G-group map, keyed
+ * by hladb version. Fetching and parsing {@code hla_ambigs.xml.zip} costs real time (a real,
+ * decompressed 1.5GB+ XML file at the time of writing, streamed and tokenized every time it's
+ * needed) -- for a <em>pinned</em> hladb version (e.g. {@code "3.65.0"}) that data can never
+ * change once IMGT/HLA publishes it, so there's no reason to re-fetch and re-parse it on every
+ * process run.
+ * <p>
+ * {@link GLStringConstants#LATEST_HLADB} ({@code "Latest"}) is the one exception: it's a moving
+ * GitHub branch, not a pinned release, so caching it forever would silently serve stale data
+ * after IMGT/HLA's next release. Entries for it expire after {@link #LATEST_TTL_MILLIS} instead
+ * of being kept indefinitely.
+ * <p>
+ * Every method here is purely best-effort: a missing, corrupt, unreadable, or expired cache
+ * entry is treated as a plain cache miss (never thrown), and a failure to write is logged and
+ * swallowed -- the caller already has a correct, freshly-parsed result regardless of whether the
+ * cache write succeeds. Nothing about correctness depends on this class working.
+ */
+class AntigenRecognitionSiteCache {
+	private static final Logger LOGGER = Logger.getLogger(AntigenRecognitionSiteCache.class.getName());
+
+	/**
+	 * Overrides the cache directory (default: {@code ~/.dash-cache/ars}). Not something a user
+	 * needs to set for normal use -- this exists for edge cases like a read-only home directory
+	 * or a container, the same spirit as {@link GLStringConstants#HLADB_PROPERTY} and friends.
+	 */
+	public static final String ARS_CACHE_DIR_PROPERTY = "org.dash.arsCacheDir";
+
+	private static final String CACHED_AT_PREFIX = "#cachedAt=";
+	private static final long LATEST_TTL_MILLIS = TimeUnit.HOURS.toMillis(24);
+
+	private AntigenRecognitionSiteCache() {
+	}
+
+	/**
+	 * @param hladb the hladb this data would be for (never null -- callers already default it)
+	 * @return the cached ARS map, or {@code null} on any cache miss (not present, unreadable,
+	 *         wrong format, or -- for {@link GLStringConstants#LATEST_HLADB} only -- expired)
+	 */
+	static HashMap<String, HashSet<String>> read(String hladb) {
+		File file = cacheFile(hladb);
+
+		if (!file.isFile()) {
+			return null;
+		}
+
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+			String header = reader.readLine();
+			if (header == null || !header.startsWith(CACHED_AT_PREFIX)) {
+				return null;
+			}
+
+			long cachedAt = Long.parseLong(header.substring(CACHED_AT_PREFIX.length()));
+			if (GLStringConstants.LATEST_HLADB.equals(hladb) && System.currentTimeMillis() - cachedAt > LATEST_TTL_MILLIS) {
+				return null;
+			}
+
+			HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				int tab = line.indexOf('\t');
+				if (tab < 0) {
+					continue;
+				}
+
+				String arsCode = line.substring(0, tab);
+				String allelesJoined = line.substring(tab + 1);
+				HashSet<String> alleles = new HashSet<String>();
+				// An empty gGroup (no gGroupAllele children) is stored as an empty string here --
+				// "".split(",") returns [""], not [], so this must be checked explicitly or a
+				// bogus single empty-string allele would be reconstructed.
+				if (!allelesJoined.isEmpty()) {
+					alleles.addAll(Arrays.asList(allelesJoined.split(",")));
+				}
+				arsMap.put(arsCode, alleles);
+			}
+
+			return arsMap;
+		}
+		catch (Exception e) {
+			LOGGER.info("Ignoring unreadable ARS cache file " + file + ": " + e);
+			return null;
+		}
+	}
+
+	/**
+	 * Best-effort write; any failure is logged and swallowed rather than propagated, since a
+	 * cache write failing doesn't affect the correctness of the result the caller already has.
+	 *
+	 * @param hladb the hladb this data is for
+	 * @param arsMap the freshly-parsed map to persist
+	 */
+	static void write(String hladb, HashMap<String, HashSet<String>> arsMap) {
+		File dir = cacheDir();
+
+		try {
+			Files.createDirectories(dir.toPath());
+
+			// Created directly inside the target directory (not the system temp dir) so the
+			// final Files.move() below is guaranteed to be on the same filesystem -- required
+			// for ATOMIC_MOVE to actually be atomic rather than silently falling back to a
+			// non-atomic copy-then-delete.
+			File tempFile = File.createTempFile("ars-", ".tmp", dir);
+
+			try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8))) {
+				writer.write(CACHED_AT_PREFIX + System.currentTimeMillis());
+				writer.newLine();
+
+				for (Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+					writer.write(entry.getKey());
+					writer.write('\t');
+					writer.write(String.join(",", entry.getValue()));
+					writer.newLine();
+				}
+			}
+
+			Files.move(tempFile.toPath(), cacheFile(hladb).toPath(),
+					StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		}
+		catch (Exception e) {
+			LOGGER.info("Couldn't write ARS cache for hladb " + hladb + ": " + e);
+		}
+	}
+
+	// Package-private (not private) so tests can locate the exact file this class would read
+	// from/write to, to exercise edge cases (corruption, expiry) that require crafting a cache
+	// file's content directly rather than going through write().
+	static File cacheFile(String hladb) {
+		// Matches the same normalization AntigenRecognitionSiteLoader#loadGGroups uses to build
+		// the fetch URL, so the cache key exactly tracks whatever actually determines the
+		// content (e.g. "3.65.0" and "3.65.0" -- the only form this ever legitimately takes --
+		// both normalize to "3650"). Sanitized defensively in case some future hladb value ever
+		// contains characters that aren't safe in a filename.
+		String normalized = hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING);
+		String safeName = normalized.replaceAll("[^A-Za-z0-9_-]", "_");
+		return new File(cacheDir(), "ars-" + safeName + ".cache");
+	}
+
+	private static File cacheDir() {
+		String override = System.getProperty(ARS_CACHE_DIR_PROPERTY);
+		if (override != null && !override.isEmpty()) {
+			return new File(override);
+		}
+
+		return new File(System.getProperty("user.home"), ".dash-cache" + File.separator + "ars");
+	}
+}

--- a/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteLoader.java
+++ b/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteLoader.java
@@ -22,7 +22,9 @@
 package org.dash.valid.ars;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -115,15 +117,40 @@ public class AntigenRecognitionSiteLoader {
 	// gGroup/gGroupAllele elements don't nest inside each other (only inside gene, whose
 	// own attributes are never used), so tracking "are we inside a gGroup" as a single flag
 	// while streaming is enough to reproduce the original nesting-scoped behavior.
+	//
+	// Two further, separately-verified findings from actually profiling this against the real
+	// file: decompressed, hla_ambigs.xml.zip is 1.5GB+ (16M+ lines), of which 99.88% is
+	// <tns:ambigCombosList> content this method never reads at all -- but a dedicated StAX
+	// implementation's own skipElement() (tested directly, via Woodstox) turned out not to help,
+	// since the underlying tokenizer still has to character-scan past skipped content either
+	// way. What does help:
+	// 1. AntigenRecognitionSiteCache -- for a *pinned* hladb (anything but LATEST_HLADB, which
+	//    is a moving branch, not a release), this data can never change once published, so
+	//    there's no reason to ever fetch or parse it more than once on a given machine.
+	// 2. Buffering the whole (compressed) response before parsing, instead of tokenizing
+	//    directly off the live network socket -- measured ~24s streamed live vs. ~13s from an
+	//    otherwise-identical already-downloaded local file for this exact file, i.e. roughly
+	//    half the wall-clock cost was network-interleaving overhead, not parsing itself.
 	public static HashMap<String, HashSet<String>> loadGGroups(String hladb) throws MalformedURLException, IOException, ParserConfigurationException, SAXException {
 		if (hladb == null) hladb = GLStringConstants.LATEST_HLADB;
+
+		HashMap<String, HashSet<String>> cached = AntigenRecognitionSiteCache.read(hladb);
+		if (cached != null) {
+			return cached;
+		}
+
 		URL url = new URL("https://raw.githubusercontent.com/ANHIG/IMGTHLA/" + hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING) + "/xml/hla_ambigs.xml.zip");
 
 		System.out.println(url.toString());
 
 		HashMap<String, HashSet<String>> gAlleleListMap = new HashMap<String, HashSet<String>>();
 
-		try (ZipInputStream zipStream = new ZipInputStream(url.openStream())) {
+		byte[] responseBytes;
+		try (InputStream urlStream = url.openStream()) {
+			responseBytes = urlStream.readAllBytes();
+		}
+
+		try (ZipInputStream zipStream = new ZipInputStream(new ByteArrayInputStream(responseBytes))) {
 			zipStream.getNextEntry();
 
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
@@ -189,6 +216,8 @@ public class AntigenRecognitionSiteLoader {
 		catch (XMLStreamException e) {
 			throw new IOException("Problem streaming IMGT/HLA ambiguity XML for hladb: " + hladb, e);
 		}
+
+		AntigenRecognitionSiteCache.write(hladb, gAlleleListMap);
 
 		return gAlleleListMap;
 	}

--- a/ld-validation/src/test/java/org/dash/valid/ars/AntigenRecognitionSiteCacheTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/ars/AntigenRecognitionSiteCacheTest.java
@@ -1,0 +1,176 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.ars;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import org.dash.valid.gl.GLStringConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class AntigenRecognitionSiteCacheTest {
+
+	@TempDir
+	Path tempCacheDir;
+
+	@BeforeEach
+	public void pointCacheAtTempDir() {
+		System.setProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY, tempCacheDir.toString());
+	}
+
+	@AfterEach
+	public void clearOverride() {
+		System.clearProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY);
+	}
+
+	@Test
+	public void testMissingCacheFileIsAPlainMiss() {
+		assertNull(AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testWriteThenReadRoundTripsForAPinnedVersion() {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01", "HLA-A*01:02")));
+		arsMap.put("HLA-B*07:02g", new HashSet<String>(java.util.Arrays.asList("HLA-B*07:02")));
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		HashMap<String, HashSet<String>> read = AntigenRecognitionSiteCache.read("3.65.0");
+
+		assertEquals(arsMap, read);
+	}
+
+	@Test
+	public void testEmptyAlleleSetRoundTrips() {
+		// A gGroup with no gGroupAllele children -- the edge case where a naive "".split(",")
+		// would reconstruct a bogus single empty-string allele instead of a truly empty set.
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*99:99g", new HashSet<String>());
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		HashMap<String, HashSet<String>> read = AntigenRecognitionSiteCache.read("3.65.0");
+
+		assertEquals(arsMap, read);
+		assertTrue(read.get("HLA-A*99:99g").isEmpty());
+	}
+
+	@Test
+	public void testDifferentHladbVersionsDoNotCollide() {
+		HashMap<String, HashSet<String>> arsMapA = new HashMap<String, HashSet<String>>();
+		arsMapA.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		HashMap<String, HashSet<String>> arsMapB = new HashMap<String, HashSet<String>>();
+		arsMapB.put("HLA-B*07:02g", new HashSet<String>(java.util.Arrays.asList("HLA-B*07:02")));
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMapA);
+		AntigenRecognitionSiteCache.write("3.60.0", arsMapB);
+
+		assertEquals(arsMapA, AntigenRecognitionSiteCache.read("3.65.0"));
+		assertEquals(arsMapB, AntigenRecognitionSiteCache.read("3.60.0"));
+	}
+
+	@Test
+	public void testPinnedVersionNeverExpires() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile("3.65.0", arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.DAYS.toMillis(365));
+
+		// A year-old cache entry for a *pinned* version must still be honored -- the data can
+		// never have changed since IMGT/HLA published that specific release.
+		assertEquals(arsMap, AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testLatestExpiresAfterTtl() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.HOURS.toMillis(25));
+
+		// Latest is a moving branch, not a pinned release -- a 25-hour-old entry must be treated
+		// as stale, not served forever.
+		assertNull(AntigenRecognitionSiteCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testLatestWithinTtlIsStillHonored() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.HOURS.toMillis(1));
+
+		assertEquals(arsMap, AntigenRecognitionSiteCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testCorruptCacheFileIsATreatedAsAMiss() throws IOException {
+		File file = AntigenRecognitionSiteCache.cacheFile("3.65.0");
+		file.getParentFile().mkdirs();
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("not a cache file at all\njust garbage\n");
+		}
+
+		assertNull(AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testWriteIsBestEffortAndDoesNotThrowWhenDirectoryCannotBeCreated() throws IOException {
+		// Point the "cache directory" at a path that's actually a regular file -- Files#createDirectories
+		// will fail, and write() must swallow that rather than propagating it, since a cache
+		// write failing must never affect the correctness of a result the caller already has.
+		File notADirectory = tempCacheDir.resolve("actually-a-file").toFile();
+		try (FileWriter writer = new FileWriter(notADirectory)) {
+			writer.write("occupying this path");
+		}
+		System.setProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY, notADirectory.getAbsolutePath());
+
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>());
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		// No exception reaching here is the actual assertion.
+	}
+
+	private void writeRawCacheFile(String hladb, HashMap<String, HashSet<String>> arsMap, long cachedAtMillis) throws IOException {
+		File file = AntigenRecognitionSiteCache.cacheFile(hladb);
+		file.getParentFile().mkdirs();
+
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("#cachedAt=" + cachedAtMillis + "\n");
+			for (java.util.Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+				writer.write(entry.getKey() + "\t" + String.join(",", entry.getValue()) + "\n");
+			}
+		}
+	}
+}


### PR DESCRIPTION
## The concern

Real feedback: the one-time ARS/IMGT reference-data load (triggered on the first genotype requiring an ARS check) takes 80-130s. Even accepting it's a one-time cost, that "seems long" — worth actually investigating rather than accepting.

## What I found

- **Network isn't the bottleneck**: the 40MB compressed `hla_ambigs.xml.zip` downloads in ~2.6s via a plain `curl`.
- **The file is enormous relative to what we need**: decompressed, it's 1.5GB / 16.3M lines — 99.88% of which is `<tns:ambigCombosList>` content this loader never reads at all (we only need `<tns:gGroupsList>`, 0.12% of the file).
- **Tried Woodstox's `skipElement()`** (the Stax2 extension API) specifically to skip those sections — measured *no improvement* over the JDK's built-in StAX parser. The underlying tokenizer still has to character-scan past skipped content to find the matching end tag either way.
- **What did measurably help**: parsing from an already-downloaded local file took ~13s vs. ~24s tokenizing directly off the live network socket for this exact file — roughly half the wall-clock cost was network-interleaving overhead, not parsing itself.

## The fix — two parts, independently useful

1. **Buffer before parsing**: `readAllBytes()` the whole compressed response first, instead of tokenizing directly off the live `URLConnection` stream.
2. **`AntigenRecognitionSiteCache`**: a local, on-disk cache for the parsed ARS map, keyed by hladb version.
   - A **pinned** version (e.g. `"3.65.0"`) can never change once IMGT/HLA publishes it — cached permanently.
   - `LATEST_HLADB` (`"Latest"`) is a moving GitHub branch, not a release — cached with a 24h TTL instead, so it can't silently go stale for weeks.
   - Text-based format (not Java serialization) for robustness across code changes; atomic write-via-rename so a reader never sees a partial write; any read/write failure is a plain cache miss, logged and swallowed — correctness never depends on this working.
   - Defaults to `~/.dash-cache/ars`, overridable via `org.dash.arsCacheDir` for edge cases (read-only home dirs, containers) — not something normal use requires touching.

**No ld-service-specific changes needed** — both fixes live entirely inside `AntigenRecognitionSiteLoader`, which the CLI and ld-service already call identically.

## Verification

- `AntigenRecognitionSiteCacheTest`: 9 tests — round-trip (including the empty-allele-set edge case where a naive `split(",")` would reconstruct a bogus entry), per-hladb isolation, pinned-version permanence, Latest TTL expiry and non-expiry, corrupt-file handling, and write-failure resilience.
- Full `ld-validation` suite: 68/68.
- Real end-to-end run against a pinned hladb: cold run (fetch+parse+write) took 29.2s; immediately re-running (cache hit) took 9.6s — confirmed against the actual cache file (685 entries, matching an independently-measured gGroup count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)