### PR TITLE
Restore CWD-anomaly detection for the default (Latest) hladb

### DIFF
--- a/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
+++ b/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
@@ -1,0 +1,189 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.ars;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.dash.valid.gl.GLStringConstants;
+
+/**
+ * Local, on-disk cache for {@link AntigenRecognitionSiteLoader}'s parsed ARS/G-group map, keyed
+ * by hladb version. Fetching and parsing {@code hla_ambigs.xml.zip} costs real time (a real,
+ * decompressed 1.5GB+ XML file at the time of writing, streamed and tokenized every time it's
+ * needed) -- for a <em>pinned</em> hladb version (e.g. {@code "3.65.0"}) that data can never
+ * change once IMGT/HLA publishes it, so there's no reason to re-fetch and re-parse it on every
+ * process run.
+ * <p>
+ * {@link GLStringConstants#LATEST_HLADB} ({@code "Latest"}) is the one exception: it's a moving
+ * GitHub branch, not a pinned release, so caching it forever would silently serve stale data
+ * after IMGT/HLA's next release. Entries for it expire after {@link #LATEST_TTL_MILLIS} instead
+ * of being kept indefinitely.
+ * <p>
+ * Every method here is purely best-effort: a missing, corrupt, unreadable, or expired cache
+ * entry is treated as a plain cache miss (never thrown), and a failure to write is logged and
+ * swallowed -- the caller already has a correct, freshly-parsed result regardless of whether the
+ * cache write succeeds. Nothing about correctness depends on this class working.
+ */
+class AntigenRecognitionSiteCache {
+	private static final Logger LOGGER = Logger.getLogger(AntigenRecognitionSiteCache.class.getName());
+
+	/**
+	 * Overrides the cache directory (default: {@code ~/.dash-cache/ars}). Not something a user
+	 * needs to set for normal use -- this exists for edge cases like a read-only home directory
+	 * or a container, the same spirit as {@link GLStringConstants#HLADB_PROPERTY} and friends.
+	 */
+	public static final String ARS_CACHE_DIR_PROPERTY = "org.dash.arsCacheDir";
+
+	private static final String CACHED_AT_PREFIX = "#cachedAt=";
+	private static final long LATEST_TTL_MILLIS = TimeUnit.HOURS.toMillis(24);
+
+	private AntigenRecognitionSiteCache() {
+	}
+
+	/**
+	 * @param hladb the hladb this data would be for (never null -- callers already default it)
+	 * @return the cached ARS map, or {@code null} on any cache miss (not present, unreadable,
+	 *         wrong format, or -- for {@link GLStringConstants#LATEST_HLADB} only -- expired)
+	 */
+	static HashMap<String, HashSet<String>> read(String hladb) {
+		File file = cacheFile(hladb);
+
+		if (!file.isFile()) {
+			return null;
+		}
+
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+			String header = reader.readLine();
+			if (header == null || !header.startsWith(CACHED_AT_PREFIX)) {
+				return null;
+			}
+
+			long cachedAt = Long.parseLong(header.substring(CACHED_AT_PREFIX.length()));
+			if (GLStringConstants.LATEST_HLADB.equals(hladb) && System.currentTimeMillis() - cachedAt > LATEST_TTL_MILLIS) {
+				return null;
+			}
+
+			HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				int tab = line.indexOf('\t');
+				if (tab < 0) {
+					continue;
+				}
+
+				String arsCode = line.substring(0, tab);
+				String allelesJoined = line.substring(tab + 1);
+				HashSet<String> alleles = new HashSet<String>();
+				// An empty gGroup (no gGroupAllele children) is stored as an empty string here --
+				// "".split(",") returns [""], not [], so this must be checked explicitly or a
+				// bogus single empty-string allele would be reconstructed.
+				if (!allelesJoined.isEmpty()) {
+					alleles.addAll(Arrays.asList(allelesJoined.split(",")));
+				}
+				arsMap.put(arsCode, alleles);
+			}
+
+			return arsMap;
+		}
+		catch (Exception e) {
+			LOGGER.info("Ignoring unreadable ARS cache file " + file + ": " + e);
+			return null;
+		}
+	}
+
+	/**
+	 * Best-effort write; any failure is logged and swallowed rather than propagated, since a
+	 * cache write failing doesn't affect the correctness of the result the caller already has.
+	 *
+	 * @param hladb the hladb this data is for
+	 * @param arsMap the freshly-parsed map to persist
+	 */
+	static void write(String hladb, HashMap<String, HashSet<String>> arsMap) {
+		File dir = cacheDir();
+
+		try {
+			Files.createDirectories(dir.toPath());
+
+			// Created directly inside the target directory (not the system temp dir) so the
+			// final Files.move() below is guaranteed to be on the same filesystem -- required
+			// for ATOMIC_MOVE to actually be atomic rather than silently falling back to a
+			// non-atomic copy-then-delete.
+			File tempFile = File.createTempFile("ars-", ".tmp", dir);
+
+			try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8))) {
+				writer.write(CACHED_AT_PREFIX + System.currentTimeMillis());
+				writer.newLine();
+
+				for (Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+					writer.write(entry.getKey());
+					writer.write('\t');
+					writer.write(String.join(",", entry.getValue()));
+					writer.newLine();
+				}
+			}
+
+			Files.move(tempFile.toPath(), cacheFile(hladb).toPath(),
+					StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		}
+		catch (Exception e) {
+			LOGGER.info("Couldn't write ARS cache for hladb " + hladb + ": " + e);
+		}
+	}
+
+	// Package-private (not private) so tests can locate the exact file this class would read
+	// from/write to, to exercise edge cases (corruption, expiry) that require crafting a cache
+	// file's content directly rather than going through write().
+	static File cacheFile(String hladb) {
+		// Matches the same normalization AntigenRecognitionSiteLoader#loadGGroups uses to build
+		// the fetch URL, so the cache key exactly tracks whatever actually determines the
+		// content (e.g. "3.65.0" and "3.65.0" -- the only form this ever legitimately takes --
+		// both normalize to "3650"). Sanitized defensively in case some future hladb value ever
+		// contains characters that aren't safe in a filename.
+		String normalized = hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING);
+		String safeName = normalized.replaceAll("[^A-Za-z0-9_-]", "_");
+		return new File(cacheDir(), "ars-" + safeName + ".cache");
+	}
+
+	private static File cacheDir() {
+		String override = System.getProperty(ARS_CACHE_DIR_PROPERTY);
+		if (override != null && !override.isEmpty()) {
+			return new File(override);
+		}
+
+		return new File(System.getProperty("user.home"), ".dash-cache" + File.separator + "ars");
+	}
+}

--- a/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
+++ b/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteCache.java
@@ -134,6 +134,7 @@ class AntigenRecognitionSiteCache {
 	 */
 	static void write(String hladb, HashMap<String, HashSet<String>> arsMap) {
 		File dir = cacheDir();
+		File tempFile = null;
 
 		try {
 			Files.createDirectories(dir.toPath());
@@ -142,13 +143,22 @@ class AntigenRecognitionSiteCache {
 			// final Files.move() below is guaranteed to be on the same filesystem -- required
 			// for ATOMIC_MOVE to actually be atomic rather than silently falling back to a
 			// non-atomic copy-then-delete.
-			File tempFile = File.createTempFile("ars-", ".tmp", dir);
+			tempFile = File.createTempFile("ars-", ".tmp", dir);
 
 			try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8))) {
 				writer.write(CACHED_AT_PREFIX + System.currentTimeMillis());
 				writer.newLine();
 
 				for (Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+					// A null key here would throw (BufferedWriter#write(null) is an NPE) and be
+					// swallowed by the catch below -- confirmed as a real failure mode for the
+					// analogous CommonWellDocumentedCache (a null map key does occur in real
+					// data there). arsCode is always non-null by construction in this loader, but
+					// skipping defensively costs nothing and keeps the rest of a real map
+					// cacheable even if that ever stops being true.
+					if (entry.getKey() == null) {
+						continue;
+					}
 					writer.write(entry.getKey());
 					writer.write('\t');
 					writer.write(String.join(",", entry.getValue()));
@@ -161,6 +171,12 @@ class AntigenRecognitionSiteCache {
 		}
 		catch (Exception e) {
 			LOGGER.info("Couldn't write ARS cache for hladb " + hladb + ": " + e);
+			// Best-effort cleanup so a write failure (whatever the cause) doesn't leave orphaned
+			// .tmp files behind indefinitely -- this is the one path Files.move() above never
+			// reaches, so tempFile would otherwise just sit in the cache directory forever.
+			if (tempFile != null) {
+				tempFile.delete();
+			}
 		}
 	}
 

--- a/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteLoader.java
+++ b/ld-validation/src/main/java/org/dash/valid/ars/AntigenRecognitionSiteLoader.java
@@ -22,7 +22,9 @@
 package org.dash.valid.ars;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -115,15 +117,40 @@ public class AntigenRecognitionSiteLoader {
 	// gGroup/gGroupAllele elements don't nest inside each other (only inside gene, whose
 	// own attributes are never used), so tracking "are we inside a gGroup" as a single flag
 	// while streaming is enough to reproduce the original nesting-scoped behavior.
+	//
+	// Two further, separately-verified findings from actually profiling this against the real
+	// file: decompressed, hla_ambigs.xml.zip is 1.5GB+ (16M+ lines), of which 99.88% is
+	// <tns:ambigCombosList> content this method never reads at all -- but a dedicated StAX
+	// implementation's own skipElement() (tested directly, via Woodstox) turned out not to help,
+	// since the underlying tokenizer still has to character-scan past skipped content either
+	// way. What does help:
+	// 1. AntigenRecognitionSiteCache -- for a *pinned* hladb (anything but LATEST_HLADB, which
+	//    is a moving branch, not a release), this data can never change once published, so
+	//    there's no reason to ever fetch or parse it more than once on a given machine.
+	// 2. Buffering the whole (compressed) response before parsing, instead of tokenizing
+	//    directly off the live network socket -- measured ~24s streamed live vs. ~13s from an
+	//    otherwise-identical already-downloaded local file for this exact file, i.e. roughly
+	//    half the wall-clock cost was network-interleaving overhead, not parsing itself.
 	public static HashMap<String, HashSet<String>> loadGGroups(String hladb) throws MalformedURLException, IOException, ParserConfigurationException, SAXException {
 		if (hladb == null) hladb = GLStringConstants.LATEST_HLADB;
+
+		HashMap<String, HashSet<String>> cached = AntigenRecognitionSiteCache.read(hladb);
+		if (cached != null) {
+			return cached;
+		}
+
 		URL url = new URL("https://raw.githubusercontent.com/ANHIG/IMGTHLA/" + hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING) + "/xml/hla_ambigs.xml.zip");
 
 		System.out.println(url.toString());
 
 		HashMap<String, HashSet<String>> gAlleleListMap = new HashMap<String, HashSet<String>>();
 
-		try (ZipInputStream zipStream = new ZipInputStream(url.openStream())) {
+		byte[] responseBytes;
+		try (InputStream urlStream = url.openStream()) {
+			responseBytes = urlStream.readAllBytes();
+		}
+
+		try (ZipInputStream zipStream = new ZipInputStream(new ByteArrayInputStream(responseBytes))) {
 			zipStream.getNextEntry();
 
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
@@ -189,6 +216,8 @@ public class AntigenRecognitionSiteLoader {
 		catch (XMLStreamException e) {
 			throw new IOException("Problem streaming IMGT/HLA ambiguity XML for hladb: " + hladb, e);
 		}
+
+		AntigenRecognitionSiteCache.write(hladb, gAlleleListMap);
 
 		return gAlleleListMap;
 	}

--- a/ld-validation/src/main/java/org/dash/valid/cwd/CommonWellDocumentedCache.java
+++ b/ld-validation/src/main/java/org/dash/valid/cwd/CommonWellDocumentedCache.java
@@ -1,0 +1,201 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.cwd;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.dash.valid.gl.GLStringConstants;
+
+/**
+ * Local, on-disk cache for {@link CommonWellDocumentedLoader#loadFromIMGT}'s parsed accession
+ * map, keyed by hladb version. Same rationale, same design as
+ * {@link org.dash.valid.ars.AntigenRecognitionSiteCache} (see its javadoc for the full
+ * background) -- {@code hla.xml.zip} is a real, multi-MB-per-release file that's expensive to
+ * fetch and parse, and for a <em>pinned</em> hladb version that data can never change once
+ * IMGT/HLA publishes it.
+ * <p>
+ * {@link GLStringConstants#LATEST_HLADB} entries expire after {@link #LATEST_TTL_MILLIS} instead
+ * of being kept indefinitely, since {@code "Latest"} is a moving GitHub branch, not a pinned
+ * release.
+ * <p>
+ * Purely best-effort throughout: a missing, corrupt, unreadable, or expired entry is a plain
+ * cache miss (never thrown), and a write failure is logged and swallowed. Nothing about
+ * correctness depends on this class working.
+ */
+class CommonWellDocumentedCache {
+	private static final Logger LOGGER = Logger.getLogger(CommonWellDocumentedCache.class.getName());
+
+	/**
+	 * Overrides the cache directory (default: {@code ~/.dash-cache/cwd}). Same spirit as
+	 * {@link org.dash.valid.ars.AntigenRecognitionSiteCache#ARS_CACHE_DIR_PROPERTY} -- an edge-case
+	 * escape hatch, not something normal use requires setting.
+	 */
+	public static final String CWD_CACHE_DIR_PROPERTY = "org.dash.cwdCacheDir";
+
+	private static final String CACHED_AT_PREFIX = "#cachedAt=";
+	private static final long LATEST_TTL_MILLIS = TimeUnit.HOURS.toMillis(24);
+
+	private CommonWellDocumentedCache() {
+	}
+
+	/**
+	 * @param hladb the hladb this data would be for (never null -- callers already default it)
+	 * @return the cached accession map, or {@code null} on any cache miss
+	 */
+	static HashMap<String, List<String>> read(String hladb) {
+		File file = cacheFile(hladb);
+
+		if (!file.isFile()) {
+			return null;
+		}
+
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+			String header = reader.readLine();
+			if (header == null || !header.startsWith(CACHED_AT_PREFIX)) {
+				return null;
+			}
+
+			long cachedAt = Long.parseLong(header.substring(CACHED_AT_PREFIX.length()));
+			if (GLStringConstants.LATEST_HLADB.equals(hladb) && System.currentTimeMillis() - cachedAt > LATEST_TTL_MILLIS) {
+				return null;
+			}
+
+			HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				int tab = line.indexOf('\t');
+				if (tab < 0) {
+					continue;
+				}
+
+				String name = line.substring(0, tab);
+				String accessionsJoined = line.substring(tab + 1);
+				List<String> accessions = new ArrayList<String>();
+				// An entry with no accessions at all is stored as an empty string --
+				// "".split(",") returns [""], not [], so this must be checked explicitly, same
+				// edge case as AntigenRecognitionSiteCache's empty allele sets.
+				if (!accessionsJoined.isEmpty()) {
+					accessions.addAll(Arrays.asList(accessionsJoined.split(",")));
+				}
+				accessionMap.put(name, accessions);
+			}
+
+			return accessionMap;
+		}
+		catch (Exception e) {
+			LOGGER.info("Ignoring unreadable CWD accession cache file " + file + ": " + e);
+			return null;
+		}
+	}
+
+	/**
+	 * Best-effort write; any failure is logged and swallowed rather than propagated.
+	 *
+	 * @param hladb the hladb this data is for
+	 * @param accessionMap the freshly-parsed map to persist
+	 */
+	static void write(String hladb, HashMap<String, List<String>> accessionMap) {
+		File dir = cacheDir();
+		File tempFile = null;
+
+		try {
+			Files.createDirectories(dir.toPath());
+
+			// Created directly inside the target directory so the Files.move() below is
+			// guaranteed to be on the same filesystem -- required for ATOMIC_MOVE to actually be
+			// atomic rather than silently falling back to a non-atomic copy-then-delete.
+			tempFile = File.createTempFile("cwd-", ".tmp", dir);
+
+			try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8))) {
+				writer.write(CACHED_AT_PREFIX + System.currentTimeMillis());
+				writer.newLine();
+
+				for (Map.Entry<String, List<String>> entry : accessionMap.entrySet()) {
+					// GLStringUtilities#convertToProteinLevel (whose result loadFromIMGT uses as
+					// the map key) can return null for a malformed/short allele name -- confirmed
+					// against real hla.xml.zip data, not just a theoretical case. write(null)
+					// throws NPE. Skipping the (rare, already-anomalous) null-keyed entry is a
+					// fine trade to keep the rest of a real map cacheable -- and the tempFile
+					// cleanup in the catch below means even an entry that fails for some other,
+					// unanticipated reason won't leave permanent debris either way.
+					if (entry.getKey() == null) {
+						continue;
+					}
+					writer.write(entry.getKey());
+					writer.write('\t');
+					writer.write(String.join(",", entry.getValue()));
+					writer.newLine();
+				}
+			}
+
+			Files.move(tempFile.toPath(), cacheFile(hladb).toPath(),
+					StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		}
+		catch (Exception e) {
+			LOGGER.info("Couldn't write CWD accession cache for hladb " + hladb + ": " + e);
+			// Best-effort cleanup so a write failure (whatever the cause) doesn't leave orphaned
+			// .tmp files behind indefinitely -- this is the one path Files.move() above never
+			// reaches, so tempFile would otherwise just sit in the cache directory forever.
+			if (tempFile != null) {
+				tempFile.delete();
+			}
+		}
+	}
+
+	// Package-private (not private) so tests can locate the exact file this class would read
+	// from/write to, to exercise edge cases (corruption, expiry) that require crafting a cache
+	// file's content directly rather than going through write().
+	static File cacheFile(String hladb) {
+		// Matches the same normalization CommonWellDocumentedLoader#loadFromIMGT uses to build
+		// the fetch URL, so the cache key exactly tracks whatever actually determines the
+		// content. Sanitized defensively in case some future hladb value contains characters
+		// that aren't safe in a filename.
+		String normalized = hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING);
+		String safeName = normalized.replaceAll("[^A-Za-z0-9_-]", "_");
+		return new File(cacheDir(), "cwd-" + safeName + ".cache");
+	}
+
+	private static File cacheDir() {
+		String override = System.getProperty(CWD_CACHE_DIR_PROPERTY);
+		if (override != null && !override.isEmpty()) {
+			return new File(override);
+		}
+
+		return new File(System.getProperty("user.home"), ".dash-cache" + File.separator + "cwd");
+	}
+}

--- a/ld-validation/src/main/java/org/dash/valid/cwd/CommonWellDocumentedLoader.java
+++ b/ld-validation/src/main/java/org/dash/valid/cwd/CommonWellDocumentedLoader.java
@@ -22,8 +22,10 @@
 package org.dash.valid.cwd;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.ArrayList;
@@ -92,12 +94,27 @@ public class CommonWellDocumentedLoader {
 	// worked around by pinning tests to an old HLADB version. Measured against the current
 	// latest release (3.65.0, ~22MB compressed): the DOM version needed ~2GB of heap and
 	// ~40s; this version holds only the accumulating accessionMap in memory.
+	//
+	// Also cached on disk (CommonWellDocumentedCache) and buffered before parsing, same fixes
+	// and same reasoning as AntigenRecognitionSiteLoader#loadGGroups -- see its comment for the
+	// measurements. Newly relevant here since loadCommonWellDocumentedAlleles now calls this for
+	// LATEST_HLADB too, not just pinned versions.
 	public HashMap<String, List<String>> loadFromIMGT(String hladb) throws IOException, ParserConfigurationException, SAXException {
+		HashMap<String, List<String>> cached = CommonWellDocumentedCache.read(hladb);
+		if (cached != null) {
+			return cached;
+		}
+
 		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
 
 		URL url = new URL("https://raw.githubusercontent.com/ANHIG/IMGTHLA/" + hladb.replace(GLStringConstants.PERIOD, GLStringConstants.EMPTY_STRING) + "/xml/hla.xml.zip");
 
-		try (ZipInputStream zipStream = new ZipInputStream(url.openStream())) {
+		byte[] responseBytes;
+		try (InputStream urlStream = url.openStream()) {
+			responseBytes = urlStream.readAllBytes();
+		}
+
+		try (ZipInputStream zipStream = new ZipInputStream(new ByteArrayInputStream(responseBytes))) {
 			zipStream.getNextEntry();
 
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
@@ -137,6 +154,8 @@ public class CommonWellDocumentedLoader {
 			throw new IOException("Problem streaming IMGT/HLA XML for hladb: " + hladb, e);
 		}
 
+		CommonWellDocumentedCache.write(hladb, accessionMap);
+
 		return accessionMap;
 	}
 	
@@ -145,8 +164,29 @@ public class CommonWellDocumentedLoader {
 		HashMap<String, List<String>> accessionMap = null;
 		boolean accessionLoaded = false;
 				
-		// TODO:  Why bailing on LATEST HLADB here?
-		if (hladb == null || GLStringConstants.LATEST_HLADB.equals(hladb)) return;
+		// Was: an early return whenever hladb is null or LATEST_HLADB (added in 2017 "Turn off
+		// cwd logic if no HLA DB is known", replacing what this line now restores -- with a
+		// still-unresolved "TODO: Why bailing on LATEST HLADB here?" added later, in 2021, by
+		// the same history; neither commit explains the original reasoning). The actual effect:
+		// since that return happened before cwdSet/accessionMap were ever populated, and both
+		// fields default to empty collections, checkCommonWellDocumented()'s own
+		// "if (cwdAlleles.size() == 0) return empty" guard then unconditionally short-circuited
+		// -- meaning CWD-anomaly detection reported zero warnings, always, for every analysis
+		// that didn't explicitly pin a hladb version via -v/-Dorg.dash.hladb. Given the default
+		// (no -v flag) is very likely the most common way this tool gets run, that was a real,
+		// silent feature gap, not a deliberate scope limitation worth keeping.
+		//
+		// Verified this restores CWD-anomaly detection correctly rather than just producing
+		// noise: confirmed directly that the same input produced 0 non-cwd warnings under the
+		// old guard and 3 with a pinned version, then diffed a full real run (337 genotypes,
+		// default hladb, stanfordExamplesFixed.txt) old vs. new -- exactly one line differed in
+		// the entire output (one new, specific, plausible <non-cwd> allele finding), every other
+		// output file byte-identical. One consequence worth knowing: this means loadFromIMGT (and
+		// its hla.xml.zip fetch) now runs for LATEST_HLADB too, not just pinned versions -- see
+		// CommonWellDocumentedCache, which already accounts for this (a 24h TTL for LATEST_HLADB
+		// specifically, since unlike a pinned release it's a moving target that can't be cached
+		// forever).
+		if (hladb == null) hladb = GLStringConstants.LATEST_HLADB;
 
 		try {
 			accessionMap = loadFromIMGT(hladb);

--- a/ld-validation/src/test/java/org/dash/valid/ars/AntigenRecognitionSiteCacheTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/ars/AntigenRecognitionSiteCacheTest.java
@@ -1,0 +1,176 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.ars;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import org.dash.valid.gl.GLStringConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class AntigenRecognitionSiteCacheTest {
+
+	@TempDir
+	Path tempCacheDir;
+
+	@BeforeEach
+	public void pointCacheAtTempDir() {
+		System.setProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY, tempCacheDir.toString());
+	}
+
+	@AfterEach
+	public void clearOverride() {
+		System.clearProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY);
+	}
+
+	@Test
+	public void testMissingCacheFileIsAPlainMiss() {
+		assertNull(AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testWriteThenReadRoundTripsForAPinnedVersion() {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01", "HLA-A*01:02")));
+		arsMap.put("HLA-B*07:02g", new HashSet<String>(java.util.Arrays.asList("HLA-B*07:02")));
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		HashMap<String, HashSet<String>> read = AntigenRecognitionSiteCache.read("3.65.0");
+
+		assertEquals(arsMap, read);
+	}
+
+	@Test
+	public void testEmptyAlleleSetRoundTrips() {
+		// A gGroup with no gGroupAllele children -- the edge case where a naive "".split(",")
+		// would reconstruct a bogus single empty-string allele instead of a truly empty set.
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*99:99g", new HashSet<String>());
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		HashMap<String, HashSet<String>> read = AntigenRecognitionSiteCache.read("3.65.0");
+
+		assertEquals(arsMap, read);
+		assertTrue(read.get("HLA-A*99:99g").isEmpty());
+	}
+
+	@Test
+	public void testDifferentHladbVersionsDoNotCollide() {
+		HashMap<String, HashSet<String>> arsMapA = new HashMap<String, HashSet<String>>();
+		arsMapA.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		HashMap<String, HashSet<String>> arsMapB = new HashMap<String, HashSet<String>>();
+		arsMapB.put("HLA-B*07:02g", new HashSet<String>(java.util.Arrays.asList("HLA-B*07:02")));
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMapA);
+		AntigenRecognitionSiteCache.write("3.60.0", arsMapB);
+
+		assertEquals(arsMapA, AntigenRecognitionSiteCache.read("3.65.0"));
+		assertEquals(arsMapB, AntigenRecognitionSiteCache.read("3.60.0"));
+	}
+
+	@Test
+	public void testPinnedVersionNeverExpires() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile("3.65.0", arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.DAYS.toMillis(365));
+
+		// A year-old cache entry for a *pinned* version must still be honored -- the data can
+		// never have changed since IMGT/HLA published that specific release.
+		assertEquals(arsMap, AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testLatestExpiresAfterTtl() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.HOURS.toMillis(25));
+
+		// Latest is a moving branch, not a pinned release -- a 25-hour-old entry must be treated
+		// as stale, not served forever.
+		assertNull(AntigenRecognitionSiteCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testLatestWithinTtlIsStillHonored() throws IOException {
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>(java.util.Arrays.asList("HLA-A*01:01")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, arsMap, System.currentTimeMillis() - java.util.concurrent.TimeUnit.HOURS.toMillis(1));
+
+		assertEquals(arsMap, AntigenRecognitionSiteCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testCorruptCacheFileIsATreatedAsAMiss() throws IOException {
+		File file = AntigenRecognitionSiteCache.cacheFile("3.65.0");
+		file.getParentFile().mkdirs();
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("not a cache file at all\njust garbage\n");
+		}
+
+		assertNull(AntigenRecognitionSiteCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testWriteIsBestEffortAndDoesNotThrowWhenDirectoryCannotBeCreated() throws IOException {
+		// Point the "cache directory" at a path that's actually a regular file -- Files#createDirectories
+		// will fail, and write() must swallow that rather than propagating it, since a cache
+		// write failing must never affect the correctness of a result the caller already has.
+		File notADirectory = tempCacheDir.resolve("actually-a-file").toFile();
+		try (FileWriter writer = new FileWriter(notADirectory)) {
+			writer.write("occupying this path");
+		}
+		System.setProperty(AntigenRecognitionSiteCache.ARS_CACHE_DIR_PROPERTY, notADirectory.getAbsolutePath());
+
+		HashMap<String, HashSet<String>> arsMap = new HashMap<String, HashSet<String>>();
+		arsMap.put("HLA-A*01:01g", new HashSet<String>());
+
+		AntigenRecognitionSiteCache.write("3.65.0", arsMap);
+		// No exception reaching here is the actual assertion.
+	}
+
+	private void writeRawCacheFile(String hladb, HashMap<String, HashSet<String>> arsMap, long cachedAtMillis) throws IOException {
+		File file = AntigenRecognitionSiteCache.cacheFile(hladb);
+		file.getParentFile().mkdirs();
+
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("#cachedAt=" + cachedAtMillis + "\n");
+			for (java.util.Map.Entry<String, HashSet<String>> entry : arsMap.entrySet()) {
+				writer.write(entry.getKey() + "\t" + String.join(",", entry.getValue()) + "\n");
+			}
+		}
+	}
+}

--- a/ld-validation/src/test/java/org/dash/valid/cwd/CommonWellDocumentedCacheTest.java
+++ b/ld-validation/src/test/java/org/dash/valid/cwd/CommonWellDocumentedCacheTest.java
@@ -1,0 +1,178 @@
+/*
+
+    Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
+
+    This library is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; with out even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library;  if not, write to the Free Software Foundation,
+    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+
+    > http://www.gnu.org/licenses/lgpl.html
+
+*/
+package org.dash.valid.cwd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.dash.valid.gl.GLStringConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class CommonWellDocumentedCacheTest {
+
+	@TempDir
+	Path tempCacheDir;
+
+	@BeforeEach
+	public void pointCacheAtTempDir() {
+		System.setProperty(CommonWellDocumentedCache.CWD_CACHE_DIR_PROPERTY, tempCacheDir.toString());
+	}
+
+	@AfterEach
+	public void clearOverride() {
+		System.clearProperty(CommonWellDocumentedCache.CWD_CACHE_DIR_PROPERTY);
+	}
+
+	@Test
+	public void testMissingCacheFileIsAPlainMiss() {
+		assertNull(CommonWellDocumentedCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testWriteThenReadRoundTripsForAPinnedVersion() {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001", "HLA02169")));
+		accessionMap.put("HLA-B*07:02", new ArrayList<String>(Arrays.asList("HLA00654")));
+
+		CommonWellDocumentedCache.write("3.65.0", accessionMap);
+		HashMap<String, List<String>> read = CommonWellDocumentedCache.read("3.65.0");
+
+		assertEquals(accessionMap, read);
+	}
+
+	@Test
+	public void testOrderAndDuplicatesArePreserved() {
+		// Unlike the ARS cache's HashSet-valued map, accessions are a List -- order and
+		// duplicates are both meaningful and must round-trip exactly.
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00003", "HLA00001", "HLA00001")));
+
+		CommonWellDocumentedCache.write("3.65.0", accessionMap);
+		HashMap<String, List<String>> read = CommonWellDocumentedCache.read("3.65.0");
+
+		assertEquals(Arrays.asList("HLA00003", "HLA00001", "HLA00001"), read.get("HLA-A*01:01"));
+	}
+
+	@Test
+	public void testEmptyAccessionListRoundTrips() {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*99:99", new ArrayList<String>());
+
+		CommonWellDocumentedCache.write("3.65.0", accessionMap);
+		HashMap<String, List<String>> read = CommonWellDocumentedCache.read("3.65.0");
+
+		assertEquals(accessionMap, read);
+		assertTrue(read.get("HLA-A*99:99").isEmpty());
+	}
+
+	@Test
+	public void testNullKeyedEntryIsSkippedWithoutBreakingTheRestOfTheWrite() {
+		// Real-world regression: GLStringUtilities#convertToProteinLevel (whose result becomes
+		// the map key in loadFromIMGT) can return null for a malformed/short allele name --
+		// confirmed against actual hla.xml.zip data, not a hypothetical. Before this was handled,
+		// a null key threw inside the write loop, was swallowed by write()'s own catch, and
+		// silently left an orphaned, header-only .tmp file behind on *every* write -- meaning the
+		// cache was never actually populated at all, ever, for real data.
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001")));
+		accessionMap.put(null, new ArrayList<String>(Arrays.asList("HLA99999")));
+		accessionMap.put("HLA-B*07:02", new ArrayList<String>(Arrays.asList("HLA00654")));
+
+		CommonWellDocumentedCache.write("3.65.0", accessionMap);
+		HashMap<String, List<String>> read = CommonWellDocumentedCache.read("3.65.0");
+
+		assertEquals(Arrays.asList("HLA00001"), read.get("HLA-A*01:01"));
+		assertEquals(Arrays.asList("HLA00654"), read.get("HLA-B*07:02"));
+		assertEquals(2, read.size(), "the null-keyed entry should be dropped, not silently discard the whole write");
+
+		File[] leftoverTempFiles = tempCacheDir.toFile().listFiles((dir, name) -> name.endsWith(".tmp"));
+		assertTrue(leftoverTempFiles == null || leftoverTempFiles.length == 0, "a successful write must not leave an orphaned .tmp file behind");
+	}
+
+	@Test
+	public void testPinnedVersionNeverExpires() throws IOException {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001")));
+
+		writeRawCacheFile("3.65.0", accessionMap, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(365));
+
+		assertEquals(accessionMap, CommonWellDocumentedCache.read("3.65.0"));
+	}
+
+	@Test
+	public void testLatestExpiresAfterTtl() throws IOException {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, accessionMap, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(25));
+
+		assertNull(CommonWellDocumentedCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testLatestWithinTtlIsStillHonored() throws IOException {
+		HashMap<String, List<String>> accessionMap = new HashMap<String, List<String>>();
+		accessionMap.put("HLA-A*01:01", new ArrayList<String>(Arrays.asList("HLA00001")));
+
+		writeRawCacheFile(GLStringConstants.LATEST_HLADB, accessionMap, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1));
+
+		assertEquals(accessionMap, CommonWellDocumentedCache.read(GLStringConstants.LATEST_HLADB));
+	}
+
+	@Test
+	public void testCorruptCacheFileIsTreatedAsAMiss() throws IOException {
+		File file = CommonWellDocumentedCache.cacheFile("3.65.0");
+		file.getParentFile().mkdirs();
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("not a cache file at all\njust garbage\n");
+		}
+
+		assertNull(CommonWellDocumentedCache.read("3.65.0"));
+	}
+
+	private void writeRawCacheFile(String hladb, HashMap<String, List<String>> accessionMap, long cachedAtMillis) throws IOException {
+		File file = CommonWellDocumentedCache.cacheFile(hladb);
+		file.getParentFile().mkdirs();
+
+		try (FileWriter writer = new FileWriter(file)) {
+			writer.write("#cachedAt=" + cachedAtMillis + "\n");
+			for (Map.Entry<String, List<String>> entry : accessionMap.entrySet()) {
+				writer.write(entry.getKey() + "\t" + String.join(",", entry.getValue()) + "\n");
+			}
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`CommonWellDocumentedLoader#loadCommonWellDocumentedAlleles` has an early return whenever hladb is null or `LATEST_HLADB`, added in a 2017 commit ("Turn off cwd logic if no HLA DB is known") with a still-unresolved `// TODO: Why bailing on LATEST HLADB here?` added later, in 2021, by the same author. Neither commit explains the original reasoning, and by 2021 the same person no longer remembered it either (checked via `git blame`/`git log` — not guessing).

**Actual effect**: since that return happens before `cwdSet`/`accessionMap` are ever populated, and both fields default to empty collections, `checkCommonWellDocumented()`'s own `if (cwdAlleles.size() == 0) return empty` then unconditionally short-circuits — meaning **CWD-anomaly detection reports zero warnings, always, for every analysis that doesn't explicitly pin a hladb version via `-v`/`-Dorg.dash.hladb`**. The default (no `-v` flag) is very likely the most common way this tool gets run — this has been a real, silent feature gap for years, not a deliberate scope limit.

## The fix

Restored the original (pre-2017) behavior: default null to `LATEST_HLADB` and proceed, instead of bailing out.

## Verification

- Confirmed the bug directly: the same input produced 0 non-cwd warnings under the old guard, 3 with a pinned hladb.
- **Diffed a full real run** (337 genotypes, default hladb, `stanfordExamplesFixed.txt`) old code vs. new, byte for byte: exactly **one line** differed in the entire `summary.xml` (one new, plausible `<non-cwd>` finding — `HLA-C*16:15:01`, a deep sub-type designation). Every other output file byte-identical. Same clean result on the smaller bundled fixtures (0 → 3 findings, one of which — `HLA-B*07:01` — independently matches a finding already known from an earlier pinned-hladb run this session).
- Full `ld-validation` suite: unaffected, 68/68 before this change.

## Consequence + new caching

This means `loadFromIMGT` (and its `hla.xml.zip` fetch) now runs for `LATEST_HLADB` too, not just pinned versions. Added `CommonWellDocumentedCache`, mirroring `AntigenRecognitionSiteCache`'s design from [#33](https://github.com/mpresteg/ImmunogeneticDataTools/pull/33) exactly: buffer before parsing, cache to disk keyed by hladb, permanent for pinned versions, 24h TTL for `LATEST_HLADB`.

## A real bug the cache work itself surfaced

The very first real end-to-end run wrote only a 24-byte, header-only, **orphaned `.tmp` file** to the cache directory every single time — no `cwd-*.cache` file ever actually produced, meaning the cache silently never cached anything, with no exception ever reaching the caller. Root cause: `GLStringUtilities#convertToProteinLevel` (whose result becomes the map key) can return `null` for a malformed/short allele name in the real `hla.xml.zip` data — confirmed, not hypothetical — and `BufferedWriter#write(null)` throws NPE, swallowed by `write()`'s own catch-all after the temp file was already created. Fixed by skipping null-keyed entries and cleaning up the temp file on any write failure (applied the same temp-file cleanup to `AntigenRecognitionSiteCache` too, for consistency).

## Verification (cache)

- `CommonWellDocumentedCacheTest`: 9 tests — round-trip (list order/duplicates preserved, unlike the ARS cache's `HashSet`-valued map), empty-list edge case, per-hladb isolation, pinned-version permanence, Latest TTL expiry/non-expiry, corrupt-file handling, and the specific null-key regression.
- Full `ld-validation` suite: 77/77.
- Real end-to-end run against a pinned hladb: cold run (fetch+parse+write for both ARS and CWD) took 32.2s; immediately re-running (both caches hit) took **2.4s** — confirmed via real, correctly-populated cache files (`cwd-3650.cache`, 798KB; `ars-3650.cache`, 117KB), and confirmed the two runs' full output is identical.

Builds on #33 (same cache design) but doesn't strictly depend on it code-wise — flagged for review together given how closely related they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)