### PR TITLE
Show software version in --help; fix broken --about metadata (#89)

### DIFF
--- a/ld-tools/pom.xml
+++ b/ld-tools/pom.xml
@@ -39,6 +39,12 @@
     <maven.enforcer.maven-version>[3.0.4,)</maven.enforcer.maven-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.targetEncoding>UTF-8</project.build.targetEncoding>
+    <!-- ${maven.build.timestamp} itself is a special case Maven's own POM interpolator
+         resolves while parsing this file (that's why it works here), but it is not exposed to
+         templating-maven-plugin's later filter-sources step the same way: confirmed by
+         testing, and a known limitation (see e.g. MASSEMBLY-603 for the same issue in a
+         different plugin). Re-exposing it under a plain property name works around that. -->
+    <build.timestamp>${maven.build.timestamp}</build.timestamp>
   </properties>
     <dependencyManagement>
     <dependencies>
@@ -96,6 +102,38 @@
 
 <build>
     <plugins>
+      <!-- Populates the git.commit.id.abbrev and (built-in) maven.build.timestamp Maven
+           properties that About.java's java-template is filtered against below. Neither was
+           ever actually wired up before (issue #89): git.commit.id.abbrev in particular isn't a
+           built-in Maven property at all, so without this plugin it was always left as a
+           literal, unresolved "${git.commit.id.abbrev}" (formerly "${git.commit.id}") in every
+           build's about output (the "about" switch, short flag -a). Its "revision" goal defaults to the
+           initialize phase, which runs before templating-maven-plugin's generate-sources
+           filtering just below, so no explicit phase binding or plugin reordering is needed
+           here. Deliberately not configuring the git.dirty flag (a working-tree-is-dirty
+           indicator this plugin also offers); see the PR discussion for issue #89. -->
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>10.0.1</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- Default since plugin v4+: exports the abbreviated id as git.commit.id.abbrev
+               either way, but spelled out since About.java's comment refers to it by name. -->
+          <commitIdGenerationMode>flat</commitIdGenerationMode>
+          <!-- Only the Maven property is needed for template filtering; a git.properties
+               file in the built jar would be unused clutter. -->
+          <generateGitPropertiesFile>false</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>

--- a/ld-tools/src/main/java-templates/org/nmdp/validation/tools/About.java
+++ b/ld-tools/src/main/java-templates/org/nmdp/validation/tools/About.java
@@ -31,8 +31,17 @@ import java.io.PrintStream;
  */
 final class About {
     private static final String ARTIFACT_ID = "${project.artifactId}";
-    private static final String BUILD_TIMESTAMP = "${maven.build.timestamp}";
-    private static final String COMMIT = "${git.commit.id}";
+    // See ld-tools/pom.xml's build.timestamp property for why this isn't the more obvious
+    // "${maven.build.timestamp}" -- that placeholder is left unresolved by
+    // templating-maven-plugin's filtering step even though Maven's own POM parser resolves it
+    // fine inside pom.xml itself.
+    private static final String BUILD_TIMESTAMP = "${build.timestamp}";
+    // git-commit-id-maven-plugin's default commitIdGenerationMode ("flat") exports the
+    // abbreviated commit id as git.commit.id.abbrev -- there is no bare git.commit.id property
+    // in that mode (it's git.commit.id.full instead). Before the plugin was wired up
+    // (see ld-tools/pom.xml), this was "${git.commit.id}" and every build left it as a literal,
+    // unresolved placeholder: nothing in the build had ever defined that Maven property.
+    private static final String COMMIT = "${git.commit.id.abbrev}";
     private static final String COPYRIGHT = "Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)";
     private static final String LICENSE = "Licensed GNU Lesser General Public License (LGPL), version 3 or later";
     private static final String VERSION = "${project.version}";
@@ -120,5 +129,18 @@ final class About {
     public static void about(final PrintStream out) {
         checkNotNull(out);
         out.print(new About().toString());
+    }
+
+    /**
+     * Return a one-line "&lt;artifactId&gt; &lt;version&gt;" identifier, e.g. {@code ld-tools 1.0.0}.
+     * Used to show the software version alongside {@code --help} output, without repeating the
+     * full about block's commit/build/copyright/license lines there too (see
+     * https://github.com/nmdp-bioinformatics/ImmunogeneticDataTools/issues/89).
+     *
+     * @return the artifact id and version, space-separated
+     */
+    public static String header() {
+        About about = new About();
+        return about.artifactId() + " " + about.version();
     }
 }

--- a/ld-tools/src/main/java/org/nmdp/validation/tools/AnalyzeGLStrings.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/AnalyzeGLStrings.java
@@ -230,10 +230,10 @@ public class AnalyzeGLStrings implements Callable<Integer> {
                 System.exit(0);
             }
             if (help.wasFound()) {
-                Usage.usage(USAGE, null, commandLine, arguments, System.out);
+                Usage.usage(About.header(), USAGE, null, commandLine, arguments, System.out);
                 System.exit(0);
             }
-            
+
             analyzeGLStrings = new AnalyzeGLStrings(inputFile.getValue(), outputFile.getValue(), hladb.getValue(), freq.getValue(), warnings.getValue(), frequencyFiles.getValue(), allelesFile.getValue());
         }
         catch (CommandLineParseException | IllegalArgumentException e) {

--- a/ld-tools/src/main/java/org/nmdp/validation/tools/NormalizeFrequencyFile.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/NormalizeFrequencyFile.java
@@ -191,7 +191,7 @@ public class NormalizeFrequencyFile implements Callable<Integer> {
                 System.exit(0);
             }
             if (help.wasFound()) {
-                Usage.usage(USAGE, null, commandLine, arguments, System.out);
+                Usage.usage(About.header(), USAGE, null, commandLine, arguments, System.out);
                 System.exit(0);
             }
             normalizeFrequencyFile = new NormalizeFrequencyFile(inputFile.getValue(), frequencies.getValue(), outputFile.getValue());

--- a/ld-tools/src/main/java/org/nmdp/validation/tools/SyntheticGLStringGenerator.java
+++ b/ld-tools/src/main/java/org/nmdp/validation/tools/SyntheticGLStringGenerator.java
@@ -313,7 +313,7 @@ public class SyntheticGLStringGenerator implements Callable<Integer> {
                 System.exit(0);
             }
             if (help.wasFound()) {
-                Usage.usage(USAGE, null, commandLine, arguments, System.out);
+                Usage.usage(About.header(), USAGE, null, commandLine, arguments, System.out);
                 System.exit(0);
             }
             generator = new SyntheticGLStringGenerator(


### PR DESCRIPTION
## Summary

Fixes [#89](https://github.com/nmdp-bioinformatics/ImmunogeneticDataTools/issues/89) ("`analyze-gl-string -h` should tell the user the software version") -- applied to all three `ld-tools` CLI tools (`analyze-gl-strings`, `normalize-frequency-file`, `synthetic-gl-string-generator`) for consistency, since they share identical `-a`/`-h` scaffolding.

- `-h`/`--help` now prints a `ld-tools 1.0.0` header above the usage block, via a new `About.header()` reused across all three tools' `help.wasFound()` branches and `dsh-commandline`'s `Usage.usage(header, ...)` overload (available since 1.1; this project is already on 1.2).

## Folded in: a real, unrelated, much older bug in the same file

While touching `About.java`, also fixed its `-a`/`--about` output, which has printed the literal unresolved `${git.commit.id}` / `${maven.build.timestamp}` placeholders in *every* build since the class was introduced in 2016 (`40d754e`) -- three years before #89 was even filed, confirmed via `git log --follow` showing no other history for the file. Not a prior attempt at #89; just copy-pasted boilerplate (its own copyright header even says `ngs-tools`, a different project) that was never fully wired up. No plugin in this build ever set the `git.commit.id` Maven property, and `templating-maven-plugin`'s filtering doesn't expose the built-in `maven.build.timestamp` the way parsing the pom itself does (a known limitation of that plugin family, e.g. `MASSEMBLY-603`).

Fixed by:
- Adding `io.github.git-commit-id:git-commit-id-maven-plugin` 10.0.1, using the abbreviated commit id (`git.commit.id.abbrev`, e.g. `066b935`) rather than the full 40-char SHA, and deliberately not surfacing the plugin's `git.dirty` flag.
- Re-exposing `${maven.build.timestamp}` under a plain `build.timestamp` property in `ld-tools/pom.xml` so `templating-maven-plugin` can actually see it.

## Verification

Built and ran all three tools' `-a`/`-h` against the real binaries:

```
$ analyze-gl-strings -a
ld-tools 1.0.0
Commit: 066b935  Build: 2026-09-07T01:06:21Z
Copyright (c) 2014-2015 National Marrow Donor Program (NMDP)
Licensed GNU Lesser General Public License (LGPL), version 3 or later

$ analyze-gl-strings -h
ld-tools 1.0.0

usage:
analyze-gl-strings [args]
...
```

Full `ld-validation` + `ld-tools` reactor test suite passes (`mvn -pl ld-validation,ld-tools -am test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)