### PR TITLE
Show build version in the browser UI footer (#89)

### DIFF
--- a/ld-service/README.md
+++ b/ld-service/README.md
@@ -65,6 +65,10 @@ Interactive docs (springdoc-openapi) are served once the app is running:
 - Swagger UI: `http://localhost:8080/swagger-ui/index.html`
 - OpenAPI JSON: `http://localhost:8080/v3/api-docs`
 
+`GET /actuator/info` reports the running build's version (`{"build":{"name":"ld-service",
+"version":"1.0.0",...}}`) -- the browser UI's footer reads this to show its own version, the
+same idea as the CLI tools' `-h`/`-a` version display.
+
 ## Browser UI
 
 Once the app is running, open **`http://localhost:8080/`** for a browser UI covering the

--- a/ld-service/pom.xml
+++ b/ld-service/pom.xml
@@ -60,6 +60,17 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-web</artifactId>
       </dependency>
+      <!-- Backs the /actuator/info endpoint the browser UI's footer reads to show its own
+           version (issue #89's ask, applied to the UI as well as the CLI tools: see
+           ld-tools' About.java/-h fix for the CLI side). The "build" info contributor that
+           powers it auto-activates once build-info goal (below) generates a
+           META-INF/build-info.properties on the classpath; no separate config needed for that
+           part, just management.endpoints.web.exposure.include=info in application.properties
+           to expose it over HTTP (only "health" is exposed by default). -->
+      <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-actuator</artifactId>
+      </dependency>
       <!-- Replaces springfox-swagger2 (Phase 3b fix for a startup crash), now bumped from
            the javax/Boot-2.x line (springdoc-openapi-ui) to the jakarta/Boot-3.x
            successor. 2.9.0 is the latest 2.x release, tracked against Boot 3.x throughout
@@ -139,6 +150,16 @@
             <configuration>
               <mainClass>org.nmdp.validation.HLAHapVServiceApplication</mainClass>
             </configuration>
+          </execution>
+          <!-- Generates target/classes/META-INF/build-info.properties (artifact, group,
+               name, version, time), which Actuator's BuildInfoContributor picks up
+               automatically to populate /actuator/info's "build" section: just the
+               version for now, per issue #89. -->
+          <execution>
+            <id>build-info</id>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/ld-service/src/main/resources/application.properties
+++ b/ld-service/src/main/resources/application.properties
@@ -17,3 +17,10 @@ spring.servlet.multipart.max-request-size=-1
 # bodies before Spring's own multipart settings above are ever consulted. -1 disables it the same
 # way as the two settings above.
 server.tomcat.max-http-form-post-size=-1
+
+# Only "health" is exposed over HTTP by default; "info" is added so the browser UI's footer can
+# read /actuator/info (populated by the build-info Maven goal in pom.xml) to show its own
+# version, same rationale as ld-tools' -h/-a version display (issue #89). Same "personal/local
+# tool" scoping as the multipart settings above applies here too -- exposing build metadata
+# publicly isn't a concern for this deployment model.
+management.endpoints.web.exposure.include=info

--- a/ld-service/src/main/resources/static/css/app.css
+++ b/ld-service/src/main/resources/static/css/app.css
@@ -237,3 +237,10 @@ details pre {
   color: var(--muted);
   font-style: italic;
 }
+
+#app-version {
+  margin-top: 2rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-align: right;
+}

--- a/ld-service/src/main/resources/static/index.html
+++ b/ld-service/src/main/resources/static/index.html
@@ -79,6 +79,8 @@
   </section>
 </main>
 
+<footer id="app-version"></footer>
+
 <script src="/js/app.js"></script>
 </body>
 </html>

--- a/ld-service/src/main/resources/static/js/app.js
+++ b/ld-service/src/main/resources/static/js/app.js
@@ -310,4 +310,25 @@
     a.remove();
     URL.revokeObjectURL(url);
   });
+
+  // Best-effort: shows the running build's version in the footer, same rationale as the CLI
+  // tools' -h/-a version display (issue #89). Silently leaves the footer empty on any failure
+  // (endpoint disabled, network hiccup, unexpected response shape) rather than showing an error
+  // for something this cosmetic.
+  (function loadVersion() {
+    const footer = document.getElementById("app-version");
+    fetch("/actuator/info")
+      .then(function (response) {
+        return response.ok ? response.json() : null;
+      })
+      .then(function (info) {
+        const build = info && info.build;
+        if (build && build.name && build.version) {
+          footer.textContent = build.name + " " + build.version;
+        }
+      })
+      .catch(function () {
+        // Best-effort, see above.
+      });
+  })();
 })();

--- a/ld-service/src/test/java/org/nmdp/validation/StaticUiTest.java
+++ b/ld-service/src/test/java/org/nmdp/validation/StaticUiTest.java
@@ -22,8 +22,11 @@
 package org.nmdp.validation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -59,5 +62,20 @@ public class StaticUiTest {
         ResponseEntity<String> js = restTemplate.getForEntity("http://localhost:" + port + "/js/app.js", String.class);
         assertEquals(HttpStatus.OK, js.getStatusCode());
         assertTrue(js.getBody().contains("/genotypes/file"), "app.js should reference the async job endpoint it actually calls");
+        assertTrue(js.getBody().contains("/actuator/info"), "app.js should reference the version endpoint it reads for the footer");
+    }
+
+    // Issue #89, applied to the UI: real end-to-end coverage of the wiring, not just "the
+    // dependency is on the classpath" -- exercises the actual build-info Maven goal's output
+    // (target/classes/META-INF/build-info.properties) flowing through Actuator's real
+    // BuildInfoContributor and web exposure config, exactly what the browser footer depends on.
+    @Test
+    public void actuatorInfoEndpointReportsTheBuildVersion() throws Exception {
+        ResponseEntity<String> response = restTemplate.getForEntity("http://localhost:" + port + "/actuator/info", String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        JsonNode build = new ObjectMapper().readTree(response.getBody()).path("build");
+        assertEquals("ld-service", build.path("name").asText());
+        assertFalse(build.path("version").asText().isEmpty(), "build.version should be populated, not just present");
     }
 }


### PR DESCRIPTION
## Summary

Extends [#89](https://github.com/nmdp-bioinformatics/ImmunogeneticDataTools/issues/89) (CLI version display, fixed in [#35](https://github.com/mpresteg/ImmunogeneticDataTools/pull/35)) to the `ld-service` browser UI. Before this, the UI showed **no version information anywhere**.

As discussed: uses Spring Boot Actuator's `/actuator/info` endpoint, and shows just the version number for now (no commit/build timestamp).

## Changes

- `spring-boot-starter-actuator` + a `build-info` goal execution on `spring-boot-maven-plugin` -- generates `META-INF/build-info.properties`, which Actuator's `BuildInfoContributor` picks up automatically for `/actuator/info`'s `build` section.
- `management.endpoints.web.exposure.include=info` (only `health` is exposed over HTTP by default).
- A small `#app-version` footer in `index.html`, populated by `app.js` via a best-effort fetch on load (fails silently -- cosmetic, not worth surfacing an error for).
- README documents the new endpoint.
- Real end-to-end test coverage added to `StaticUiTest` (already the home for "did the build actually wire this up correctly" checks): asserts `/actuator/info` returns a populated `build.version` through the real build-info-to-Actuator-to-HTTP path.

## Verification

Ran the actual packaged jar and hit the real endpoint:

```
$ curl localhost:8080/actuator/info
{"build":{"artifact":"ld-service","name":"ld-service","time":"...","version":"1.0.0","group":"org.nmdp.validation"}}
```

Confirmed in a real browser that the footer renders `ld-service 1.0.0`, styled consistently with the rest of the page (muted color, small, right-aligned).

Full `ld-validation` + `ld-service` reactor test suite passes: 13 tests (up from 12 -- the one new test above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)